### PR TITLE
[JIT-1016] Add metrics to unbounded queues + misc fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,14 @@
+.dockerignore
+.git/
+.github/
+.gitignore
+.idea/
+README.md
+b
+Dockerfile
+docker-compose.yaml
+docker-output/
+f
+p
+secondary/
 target/

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -1,0 +1,65 @@
+name: Setup Rust
+description: Installs rust in a bare metal fashion
+inputs:
+  caller-workflow-name:
+    description: 'Name of workflow used for creating a cache key in ASCII format.'
+    required: true
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Generate cache key
+      id: cache-key-generator
+      run: echo "cache-key=$(echo ${{inputs.caller-workflow-name}} | tr ' ' '_')" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Check cache key
+      run: "echo Cache key: ${{ steps.cache-key-generator.outputs.cache-key }}"
+      shell: bash
+
+    - name: Install Protobuf
+      run: |
+        export PROTOC_VERSION=21.12 && \
+        export PROTOC_ZIP=protoc-$PROTOC_VERSION-linux-x86_64.zip && \
+        curl -Ss -OL https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP \
+        && sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc \
+        && sudo unzip -o $PROTOC_ZIP -d /usr/local include/* \
+        && rm -f $PROTOC_ZIP
+      shell: bash
+
+    - name: cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo
+        key: ${{ runner.os }}-cargo-${{ steps.cache-key-generator.outputs.cache-key }}-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: cache rust files
+      uses: actions/cache@v3
+      with:
+        path: |
+          target/
+        key: ${{ runner.os }}-cargo-${{ steps.cache-key-generator.outputs.cache-key }}-${{ hashFiles('**/*.rs') }}
+
+    - name: Check rust version before
+      run: |
+        rustc --version || true;
+        cargo --version || true;
+        cargo clippy --version || true;
+        cargo fmt --version || true;
+      shell: bash
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        components: clippy, rustfmt
+
+    - name: Check rust version after
+      run: |
+        rustc --version;
+        cargo --version;
+        cargo clippy --version;
+        cargo fmt --version;
+      shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+        # Ignore the failure of a step and avoid terminating the job.
+        continue-on-error: true
+
       - name: Build containers
         run: docker compose build --progress=plain
         env:

--- a/.github/workflows/clean_code.yaml
+++ b/.github/workflows/clean_code.yaml
@@ -12,20 +12,23 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-      - uses: actions-rs/toolchain@v1
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: nightly
-          override: true
-          components: clippy
+          caller-workflow-name: clippy_and_udeps_check
+
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GHUB_TOKEN }}
           args: --all-features
+
       - uses: actions-rs/cargo@v1
         with:
           command: install
           args: cargo-udeps --locked
-      - name: cargo udeps
+
+      - name: Run cargo udeps
         uses: actions-rs/cargo@v1
         with:
           command: udeps

--- a/.github/workflows/push_images.yaml
+++ b/.github/workflows/push_images.yaml
@@ -27,7 +27,7 @@ jobs:
           ORG: jitolabs
           TAG: ${{ inputs.TAG }}
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PWD }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,5 +9,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
+
+    - name: Setup Rust
+      uses: ./.github/actions/setup-rust
+      with:
+        caller-workflow-name: test
+
     - name: Run tests
       run: RUST_LOG=info cargo test

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .idea/
 
 .env
+docker-output/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,16 +60,16 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -82,15 +82,15 @@ checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "alloc-no-stdlib"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -114,22 +114,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.63"
+name = "anstream"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
+checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-wincon",
+ "concolor-override",
+ "concolor-query",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "arc-swap"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "arrayref"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
@@ -145,9 +185,9 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6690c370453db30743b373a60ba498fc0d6d83b11f4abfd87a84a075db5dd4"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -156,7 +196,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.14",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -165,8 +205,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -177,8 +217,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -190,9 +230,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
 dependencies = [
  "brotli",
  "flate2",
@@ -213,34 +253,35 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
- "syn 1.0.109",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
- "syn 1.0.109",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -255,7 +296,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi 0.3.9",
 ]
@@ -268,21 +309,21 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "autotools"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8138adefca3e5d2e73bfba83bd6eeaf904b26a7ac1b4a19892cfe16cc7e1701"
+checksum = "aef8da1805e028a172334c3b680f93e71126f2327622faef2ec3d893c0a4ad77"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
 dependencies = [
  "async-trait",
- "axum-core 0.2.9",
+ "axum-core",
  "bitflags",
  "bytes",
  "futures-util",
@@ -290,70 +331,24 @@ dependencies = [
  "http-body",
  "hyper",
  "itoa",
- "matchit 0.5.0",
+ "matchit",
  "memchr",
  "mime",
- "percent-encoding 2.1.0",
- "pin-project-lite",
- "serde",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
-dependencies = [
- "async-trait",
- "axum-core 0.3.2",
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa",
- "matchit 0.7.0",
- "memchr",
- "mime",
- "percent-encoding 2.1.0",
+ "percent-encoding 2.2.0",
  "pin-project-lite",
  "rustversion",
  "serde",
  "sync_wrapper",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.2.9"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -373,7 +368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom 0.2.7",
+ "getrandom 0.2.9",
  "instant",
  "pin-project-lite",
  "rand 0.8.5",
@@ -388,15 +383,21 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2b2456fd614d856680dcd9fcc660a51a820fa09daef2e49772b56a193c8474"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bincode"
@@ -409,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -419,11 +420,12 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -443,16 +445,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
+checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if 1.0.0",
  "constant_time_eq",
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -467,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -499,7 +501,7 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.56",
  "syn 1.0.109",
 ]
 
@@ -509,8 +511,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -520,8 +522,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -538,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.2"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -554,18 +556,19 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bv"
@@ -579,22 +582,22 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.2.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9e1f5fa78f69496407a27ae9ed989e3c3b072310286f5ef385525e4cbc24a9"
+checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
- "syn 1.0.109",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -605,15 +608,15 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bzip2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -640,7 +643,7 @@ dependencies = [
  "async_once",
  "cached_proc_macro",
  "cached_proc_macro_types",
- "futures 0.3.24",
+ "futures 0.3.28",
  "hashbrown 0.13.2",
  "instant",
  "lazy_static",
@@ -657,8 +660,8 @@ checksum = "e10ca87c81aaa3a949dbbe2b5e6c2c45dbc94ba4897e45ea31ff9ec5087be3dc"
 dependencies = [
  "cached_proc_macro_types",
  "darling",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -670,9 +673,9 @@ checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "caps"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938c50180feacea622ef3b8f4a496057c868dcf8ac7a64d781dd8f3f51a9c143"
+checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
 dependencies = [
  "libc",
  "thiserror",
@@ -680,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -710,16 +713,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi 0.3.9",
 ]
@@ -744,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
@@ -754,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.3.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
@@ -780,32 +783,54 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.19"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d43934757334b5c0519ff882e1ab9647ac0258b47c24c4f490d78e42697fd5"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap 0.16.0",
+]
+
+[[package]]
+name = "clap"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.4.1",
+ "strsim 0.10.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
- "heck 0.4.0",
- "proc-macro-error",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
- "syn 1.0.109",
+ "heck 0.4.1",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -818,12 +843,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.49"
+name = "clap_lex"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "cc",
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -840,17 +872,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.1"
+name = "concolor-override"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "console"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
- "terminal_size",
  "unicode-width",
- "winapi 0.3.9",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -865,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "console_log"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
+checksum = "e89f72f65e8501878b8a004d5a1afb780987e2ce2b4532c562e367a72c57499f"
 dependencies = [
  "log",
  "web-sys",
@@ -881,9 +927,9 @@ checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "convert_case"
@@ -903,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core_affinity"
@@ -921,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -939,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -949,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
@@ -960,26 +1006,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.10"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset",
- "once_cell",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if 1.0.0",
- "once_cell",
 ]
 
 [[package]]
@@ -1032,10 +1076,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.14.2"
+name = "cxx"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "scratch",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1043,26 +1131,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
- "quote 1.0.21",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -1087,14 +1175,14 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.3",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "der"
@@ -1107,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "8.1.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d4bc9b0db0a0df9ae64634ac5bdefb7afcb534e182275ca0beadbe486701c1"
+checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -1132,19 +1220,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "rustc_version",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "dialoguer"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92e7e37ecef6857fdc0c0c5d42fd5b0938e46590c2183cc92dd310a6d078eb1"
+checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
 dependencies = [
  "console",
+ "shell-words",
  "tempfile",
  "zeroize",
 ]
@@ -1160,11 +1249,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -1205,8 +1294,8 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -1241,9 +1330,9 @@ checksum = "abe71d579d1812060163dff96056261deb5bf6729b100fa2e36a68b9649ba3d3"
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "signature",
 ]
@@ -1271,14 +1360,14 @@ dependencies = [
  "derivation-path",
  "ed25519-dalek",
  "hmac 0.12.1",
- "sha2 0.10.3",
+ "sha2 0.10.6",
 ]
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encode_unicode"
@@ -1288,9 +1377,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1310,34 +1399,55 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8958699f9359f0b04e691a13850d48b7de329138023876d07cbd024c2c820598"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "enum_dispatch"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb359f1476bf611266ac1f5355bc14aeca37b299d0ebccc038ee7058891c9cb"
+checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1372,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -1387,14 +1497,14 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "filetime"
-version = "0.2.17"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
- "windows-sys",
+ "redox_syscall 0.2.16",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1405,9 +1515,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1436,19 +1546,18 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding 2.2.0",
 ]
 
 [[package]]
 name = "fs_extra"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1458,9 +1567,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1473,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1483,15 +1592,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1501,38 +1610,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
- "syn 1.0.109",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -1558,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "serde",
  "typenum",
@@ -1592,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1605,15 +1714,15 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1629,7 +1738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8af59a261bcf42f45d1b261232847b9b850ba0a1419d6100698246fb66e9240"
 dependencies = [
  "arc-swap",
- "futures 0.3.24",
+ "futures 0.3.28",
  "log",
  "reqwest",
  "serde",
@@ -1637,7 +1746,7 @@ dependencies = [
  "serde_json",
  "simpl",
  "smpl_jwt",
- "time 0.3.14",
+ "time 0.3.20",
  "tokio",
 ]
 
@@ -1654,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1706,18 +1815,18 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "headers"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
  "http",
  "httpdate",
  "mime",
- "sha-1 0.10.0",
+ "sha1",
 ]
 
 [[package]]
@@ -1740,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1752,6 +1861,21 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "histogram"
@@ -1775,7 +1899,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1790,10 +1914,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "0.2.8"
+name = "hostname"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -1810,12 +1945,6 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
@@ -1837,9 +1966,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1866,7 +1995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
 dependencies = [
  "bytes",
- "futures 0.3.24",
+ "futures 0.3.28",
  "headers",
  "http",
  "hyper",
@@ -1879,13 +2008,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.6",
+ "rustls 0.20.8",
  "tokio",
  "tokio-rustls 0.23.4",
 ]
@@ -1917,16 +2046,26 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.47"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "winapi 0.3.9",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -1948,11 +2087,10 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -1970,7 +2108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
  "bitmaps",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "rand_xoshiro",
  "rayon",
  "serde",
@@ -1987,9 +2125,9 @@ checksum = "5a9d968042a4902e08810946fc7cd5851eb75e80301342305af755ca06cb82ce"
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -2027,25 +2165,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.5.0"
+name = "io-lifetimes"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jito-block-engine"
@@ -2055,14 +2216,14 @@ dependencies = [
  "dashmap 5.4.0",
  "jito-protos",
  "log",
- "prost-types 0.10.1",
+ "prost-types 0.11.8",
  "solana-metrics",
  "solana-perf",
  "solana-sdk",
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic 0.7.2",
+ "tonic 0.8.3",
 ]
 
 [[package]]
@@ -2094,12 +2255,20 @@ name = "jito-packet-blaster"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "clap 3.2.19",
+ "clap 4.2.1",
  "env_logger",
+ "futures-util",
  "log",
+ "once_cell",
+ "quinn 0.9.3",
+ "rand 0.8.5",
+ "rustls 0.20.8",
  "solana-client",
+ "solana-net-utils",
  "solana-perf",
  "solana-sdk",
+ "solana-streamer",
+ "thiserror",
  "tokio",
 ]
 
@@ -2108,12 +2277,12 @@ name = "jito-protos"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "prost 0.10.4",
- "prost-types 0.10.1",
+ "prost 0.11.8",
+ "prost-types 0.11.8",
  "solana-perf",
  "solana-sdk",
- "tonic 0.7.2",
- "tonic-build 0.7.2",
+ "tonic 0.8.3",
+ "tonic-build 0.8.4",
 ]
 
 [[package]]
@@ -2130,10 +2299,10 @@ dependencies = [
  "keyed_priority_queue",
  "log",
  "openssl",
- "prost-types 0.10.1",
+ "prost-types 0.11.8",
  "rand 0.8.5",
  "serde",
- "sha2 0.10.3",
+ "sha2 0.10.6",
  "solana-client",
  "solana-metrics",
  "solana-perf",
@@ -2141,7 +2310,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic 0.7.2",
+ "tonic 0.8.3",
 ]
 
 [[package]]
@@ -2149,6 +2318,7 @@ name = "jito-rpc"
 version = "0.1.0"
 dependencies = [
  "crossbeam-channel",
+ "dashmap 5.4.0",
  "log",
  "solana-client",
  "solana-metrics",
@@ -2160,10 +2330,11 @@ name = "jito-transaction-relayer"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "clap 3.2.19",
+ "clap 4.2.1",
  "crossbeam-channel",
  "dashmap 5.4.0",
  "env_logger",
+ "hostname",
  "itertools",
  "jito-block-engine",
  "jito-core",
@@ -2173,7 +2344,7 @@ dependencies = [
  "jwt",
  "log",
  "openssl",
- "prost-types 0.10.1",
+ "prost-types 0.11.8",
  "reqwest",
  "solana-address-lookup-table-program",
  "solana-client",
@@ -2185,23 +2356,23 @@ dependencies = [
  "solana-sdk",
  "tokio",
  "tokio-stream",
- "tonic 0.7.2",
+ "tonic 0.8.3",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2224,7 +2395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
 dependencies = [
  "derive_more",
- "futures 0.3.24",
+ "futures 0.3.28",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
@@ -2239,7 +2410,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
- "futures 0.3.24",
+ "futures 0.3.28",
  "futures-executor",
  "futures-util",
  "log",
@@ -2254,7 +2425,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51da17abecbdab3e3d4f26b01c5ec075e88d3abe3ab3b05dc9aa69392764ec0"
 dependencies = [
- "futures 0.3.24",
+ "futures 0.3.28",
  "jsonrpc-client-transports",
 ]
 
@@ -2265,8 +2436,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
 dependencies = [
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2276,7 +2447,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
 dependencies = [
- "futures 0.3.24",
+ "futures 0.3.28",
  "hyper",
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -2292,7 +2463,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240f87695e6c6f62fb37f05c02c04953cf68d6408b8c1c89de85c7a0125b1011"
 dependencies = [
- "futures 0.3.24",
+ "futures 0.3.28",
  "jsonrpc-core",
  "lazy_static",
  "log",
@@ -2308,7 +2479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
 dependencies = [
  "bytes",
- "futures 0.3.24",
+ "futures 0.3.28",
  "globset",
  "jsonrpc-core",
  "lazy_static",
@@ -2325,21 +2496,24 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "crypto-common",
- "digest 0.10.3",
+ "digest 0.10.6",
  "hmac 0.12.1",
  "openssl",
  "serde",
  "serde_json",
- "sha2 0.10.3",
+ "sha2 0.10.6",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -2374,15 +2548,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libloading"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
@@ -2390,15 +2564,15 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.8.0+7.4.4"
+version = "0.8.3+7.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+checksum = "557b255ff04123fcc176162f56ed0c9cd42d8f357cf55b3fabeb60f7413741b3"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2468,16 +2642,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
-name = "lock_api"
-version = "0.4.8"
+name = "linux-raw-sys"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2522,16 +2711,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.9"
+name = "match_cfg"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
-name = "matchit"
-version = "0.5.0"
+name = "matches"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -2547,9 +2736,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.7"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
 ]
@@ -2564,6 +2753,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,15 +2769,15 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "min-max-heap"
@@ -2595,9 +2793,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -2640,8 +2838,8 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2653,9 +2851,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2671,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.37"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -2682,21 +2880,21 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -2763,8 +2961,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2812,42 +3010,33 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.5.7"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.7"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
- "proc-macro-crate 1.2.1",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro-crate 1.3.1",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2858,18 +3047,18 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "oid-registry"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4bda43fd1b844cbc6e6e54b5444e2b1bc7838bce59ad205902cccbb26d6761"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
 dependencies = [
  "asn1-rs",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -2879,9 +3068,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.41"
+version = "0.10.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+checksum = "4d2f106ab837a24e03672c59b1239669a0596406ff657c3c0835b6b7f0f35a33"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2894,13 +3083,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
- "syn 1.0.109",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2911,20 +3100,19 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.22.0+1.1.1q"
+version = "111.25.2+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+checksum = "320708a054ad9b3bf314688b5db87cf4d6683d64cfc835e2337924ae62bf4431"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "openssl-src",
@@ -2934,15 +3122,15 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "ouroboros"
-version = "0.15.4"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f56a2b0aa5fc88687aaf63e85a7974422790ce3419a2e1a15870f8a55227822"
+checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
 dependencies = [
  "aliasable",
  "ouroboros_macro",
@@ -2950,14 +3138,14 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.15.4"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c40641e27d0eb38cae3dee081d920104d2db47a8e853c1a592ef68d33f5ebf4"
+checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -2969,7 +3157,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -2979,34 +3167,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.3"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3024,7 +3212,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -3035,11 +3223,11 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -3050,9 +3238,9 @@ checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "percentage"
@@ -3065,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.3.0"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
+checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3075,9 +3263,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.3.0"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905708f7f674518498c1f8d644481440f476d39ca6ecae83319bba7c6c12da91"
+checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3085,33 +3273,33 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.3.0"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5803d8284a629cc999094ecd630f55e91b561a1d1ba75e233b00ae13b91a69ad"
+checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
- "syn 1.0.109",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.3.0"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1538eb784f07615c6d9a8ab061089c6c54a344c5b4301db51990ca1c241e8c04"
+checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
 dependencies = [
  "once_cell",
  "pest",
- "sha-1 0.10.0",
+ "sha2 0.10.6",
 ]
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -3132,8 +3320,8 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -3162,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plain"
@@ -3186,17 +3374,17 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49e86d2c26a24059894a3afa13fd17d063419b05dfb83f06d9c3566060c3f5a"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.56",
  "syn 1.0.109",
 ]
 
@@ -3211,13 +3399,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "thiserror",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3227,8 +3414,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
  "version_check",
 ]
@@ -3239,8 +3426,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "version_check",
 ]
 
@@ -3255,9 +3442,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -3274,22 +3461,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.10.4"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
 dependencies = [
  "bytes",
- "prost-derive 0.10.1",
-]
-
-[[package]]
-name = "prost"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3933d3ac2717077b3d5f42b40f59edfb1fb6a8c14e1c7de0f38075c4bac8e314"
-dependencies = [
- "bytes",
- "prost-derive 0.11.7",
+ "prost-derive 0.11.8",
 ]
 
 [[package]]
@@ -3314,42 +3491,20 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.10.4"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
+checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
 dependencies = [
  "bytes",
- "cfg-if 1.0.0",
- "cmake",
- "heck 0.4.0",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost 0.10.4",
- "prost-types 0.10.1",
- "regex",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24be1d23b4552a012093e1b93697b73d644ae9590e3253d878d0e77d411b614"
-dependencies = [
- "bytes",
- "heck 0.4.0",
+ "heck 0.4.1",
  "itertools",
  "lazy_static",
  "log",
  "multimap",
  "petgraph",
  "prettyplease",
- "prost 0.11.7",
- "prost-types 0.11.7",
+ "prost 0.11.8",
+ "prost-types 0.11.8",
  "regex",
  "syn 1.0.109",
  "tempfile",
@@ -3364,34 +3519,21 @@ checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.10.1"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9935362e8369bc3acd874caeeae814295c504c2bdbcde5c024089cf8b4dc12"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -3407,28 +3549,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.10.1"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
 dependencies = [
- "bytes",
- "prost 0.10.4",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de56acd5cc9642cac2a9518d4c8c53818905398fe42d33235859e0d542a7695"
-dependencies = [
- "prost 0.11.7",
+ "prost 0.11.8",
 ]
 
 [[package]]
 name = "protobuf-src"
-version = "1.0.5+3.19.3"
+version = "1.1.0+21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe57f68bf9767f48f8cbcbceb5da21524e2b1330a821c1c2502c447d8043f078"
+checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
 dependencies = [
  "autotools",
 ]
@@ -3439,7 +3571,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 dependencies = [
- "percent-encoding 2.1.0",
+ "percent-encoding 2.2.0",
 ]
 
 [[package]]
@@ -3452,9 +3584,27 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "fxhash",
- "quinn-proto",
- "quinn-udp",
- "rustls 0.20.6",
+ "quinn-proto 0.8.4",
+ "quinn-udp 0.1.4",
+ "rustls 0.20.8",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445cbfe2382fa023c4f2f3c7e1c95c03dcc1df2bf23cebcb2b13e1402c4394d1"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto 0.9.3",
+ "quinn-udp 0.3.2",
+ "rustc-hash",
+ "rustls 0.20.8",
  "thiserror",
  "tokio",
  "tracing",
@@ -3471,7 +3621,7 @@ dependencies = [
  "fxhash",
  "rand 0.8.5",
  "ring",
- "rustls 0.20.6",
+ "rustls 0.20.8",
  "rustls-native-certs",
  "rustls-pemfile 0.2.1",
  "slab",
@@ -3482,17 +3632,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn-udp"
-version = "0.1.3"
+name = "quinn-proto"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f832d8958db3e84d2ec93b5eb2272b45aa23cf7f8fe6e79f578896f4e6c231b"
+checksum = "67c10f662eee9c94ddd7135043e544f3c82fa839a1e7b865911331961b53186c"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls 0.20.8",
+ "rustls-native-certs",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07946277141531aea269befd949ed16b2c85a780ba1043244eda0969e538e54"
 dependencies = [
  "futures-util",
  "libc",
- "quinn-proto",
+ "quinn-proto 0.8.4",
  "socket2",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
+dependencies = [
+ "libc",
+ "quinn-proto 0.9.3",
+ "socket2",
+ "tracing",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3506,11 +3688,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.56",
 ]
 
 [[package]]
@@ -3534,7 +3716,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3554,7 +3736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3568,11 +3750,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -3590,26 +3772,24 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -3625,7 +3805,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.14",
+ "time 0.3.20",
  "yasna",
 ]
 
@@ -3639,13 +3819,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.7",
- "redox_syscall",
+ "getrandom 0.2.9",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -3661,14 +3850,14 @@ dependencies = [
  "lru",
  "parking_lot 0.11.2",
  "smallvec",
- "spin 0.9.4",
+ "spin 0.9.8",
 ]
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3677,27 +3866,18 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi 0.3.9",
-]
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
  "async-compression",
- "base64 0.13.0",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3714,10 +3894,10 @@ dependencies = [
  "mime",
  "native-tls",
  "once_cell",
- "percent-encoding 2.1.0",
+ "percent-encoding 2.2.0",
  "pin-project-lite",
- "rustls 0.20.6",
- "rustls-pemfile 1.0.1",
+ "rustls 0.20.8",
+ "rustls-pemfile 1.0.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3726,7 +3906,7 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tokio-util 0.7.2",
  "tower-service",
- "url 2.2.2",
+ "url 2.3.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3773,9 +3953,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
 
 [[package]]
 name = "rustc-hash"
@@ -3802,12 +3982,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.37.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aef160324be24d31a62147fae491c14d2204a3865c7ca8c3b0d7f7bcb3ea635"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "log",
  "ring",
  "sct 0.6.1",
@@ -3816,9 +4010,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -3833,7 +4027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.1",
+ "rustls-pemfile 1.0.2",
  "schannel",
  "security-framework",
 ]
@@ -3844,29 +4038,29 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.21.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -3879,12 +4073,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3892,6 +4085,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "scroll"
@@ -3908,8 +4107,8 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -3935,9 +4134,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3948,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3958,44 +4157,44 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
- "syn 1.0.109",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",
@@ -4041,13 +4240,24 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.6",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -4065,13 +4275,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899bf02746a2c92bf1053d9327dadb252b01af1f81f90cdb902411f518bc7215"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -4088,13 +4298,19 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
  "keccak",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
@@ -4104,18 +4320,18 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "signature"
-version = "1.6.0"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "simpl"
@@ -4135,18 +4351,18 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smpl_jwt"
@@ -4154,21 +4370,21 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b6ff8c21c74ce7744643a7cddbb02579a44f1f77e4316bff1ddb741aca8ac9"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "log",
  "openssl",
  "serde",
  "serde_derive",
  "serde_json",
  "simpl",
- "time 0.3.14",
+ "time 0.3.20",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -4180,9 +4396,9 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "bytes",
- "futures 0.3.24",
+ "futures 0.3.28",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -4196,7 +4412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b04c1316932017ae5f947e83d77cc0356c4a395130a480cdc17ffb0570a0c115"
 dependencies = [
  "Inflector",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bincode",
  "bs58",
  "bv",
@@ -4303,7 +4519,7 @@ dependencies = [
  "thiserror",
  "tiny-bip39",
  "uriparse",
- "url 2.2.2",
+ "url 2.3.1",
 ]
 
 [[package]]
@@ -4319,7 +4535,7 @@ dependencies = [
  "serde_yaml",
  "solana-clap-utils",
  "solana-sdk",
- "url 2.2.2",
+ "url 2.3.1",
 ]
 
 [[package]]
@@ -4330,14 +4546,14 @@ checksum = "a3e270b1afd0b360c2aec42ae302ae7980ebb226017275b32a6156ab2ccbdad9"
 dependencies = [
  "async-mutex",
  "async-trait",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bincode",
  "bs58",
  "bytes",
  "clap 2.34.0",
  "crossbeam-channel",
  "enum_dispatch",
- "futures 0.3.24",
+ "futures 0.3.28",
  "futures-util",
  "indexmap",
  "indicatif",
@@ -4345,13 +4561,13 @@ dependencies = [
  "jsonrpc-core",
  "lazy_static",
  "log",
- "quinn",
- "quinn-proto",
+ "quinn 0.8.5",
+ "quinn-proto 0.8.4",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rayon",
  "reqwest",
- "rustls 0.20.6",
+ "rustls 0.20.8",
  "semver",
  "serde",
  "serde_derive",
@@ -4373,7 +4589,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tungstenite",
- "url 2.2.2",
+ "url 2.3.1",
 ]
 
 [[package]]
@@ -4407,7 +4623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4d6cfee8fe91a3bbf6881a92335214fbf2dd0b1ef0744fab00a224167901431"
 dependencies = [
  "ahash",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bincode",
  "bs58",
  "chrono",
@@ -4530,13 +4746,13 @@ dependencies = [
  "log",
  "memmap2",
  "once_cell",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "rustc_version",
  "serde",
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2 0.10.3",
+ "sha2 0.10.6",
  "solana-frozen-abi-macro",
  "subtle",
  "thiserror",
@@ -4548,8 +4764,8 @@ version = "1.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be23cc7a382f54dfe1348edb94610e5cc146b8eb21563cdd04062a403c75ba62"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -4648,7 +4864,7 @@ dependencies = [
  "crossbeam-channel",
  "dashmap 4.0.2",
  "fs_extra",
- "futures 0.3.24",
+ "futures 0.3.28",
  "itertools",
  "lazy_static",
  "libc",
@@ -4656,7 +4872,7 @@ dependencies = [
  "lru",
  "num_cpus",
  "num_enum",
- "prost 0.11.7",
+ "prost 0.11.8",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rayon",
@@ -4665,7 +4881,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_bytes",
- "sha2 0.10.3",
+ "sha2 0.10.6",
  "solana-account-decoder",
  "solana-bpf-loader-program",
  "solana-entry",
@@ -4746,7 +4962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6d7093739e143d5e2edf3e81e523d47228adb802b847d66f4ab819be7ad6dc8"
 dependencies = [
  "bincode",
- "clap 3.2.19",
+ "clap 3.2.23",
  "crossbeam-channel",
  "log",
  "nix",
@@ -4758,7 +4974,7 @@ dependencies = [
  "solana-sdk",
  "solana-version",
  "tokio",
- "url 2.2.2",
+ "url 2.3.1",
 ]
 
 [[package]]
@@ -4813,7 +5029,7 @@ version = "1.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0937481f080f5dd495fae456c94718a7bacf30fb5fdabb02dcb8a9622e446d5"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "bincode",
  "bitflags",
  "blake3",
@@ -4826,14 +5042,14 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
- "getrandom 0.2.7",
+ "getrandom 0.2.9",
  "itertools",
  "js-sys",
  "lazy_static",
  "libc",
  "libsecp256k1",
  "log",
- "memoffset",
+ "memoffset 0.6.5",
  "num-derive",
  "num-traits",
  "parking_lot 0.12.1",
@@ -4845,8 +5061,8 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2 0.10.3",
- "sha3 0.10.2",
+ "sha2 0.10.6",
+ "sha3 0.10.6",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-sdk-macro",
@@ -4862,7 +5078,7 @@ version = "1.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4d12047608bac77fca000e18f7a2df3c7fa90656d7c7d387b1cd7faf18b238c"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "bincode",
  "eager",
  "enum-iterator",
@@ -4918,7 +5134,7 @@ version = "1.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b1fcf0dbad773e4ac97ac0540c0ad3fbcc606eb55064323cc2a2a132c5d2f"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "bincode",
  "bs58",
  "crossbeam-channel",
@@ -5033,7 +5249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "390e7481c56dda2ceab2652beeda30a533e9667b34861a2eb4eec92fa1d826d7"
 dependencies = [
  "assert_matches",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bincode",
  "bitflags",
  "borsh",
@@ -5042,7 +5258,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "derivation-path",
- "digest 0.10.3",
+ "digest 0.10.6",
  "ed25519-dalek",
  "ed25519-dalek-bip32",
  "generic-array",
@@ -5065,8 +5281,8 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2 0.10.3",
- "sha3 0.10.2",
+ "sha2 0.10.6",
+ "sha3 0.10.6",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-logger",
@@ -5084,8 +5300,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d0acbad862093ea123f3a27364336dcb0c8373522cd6810496a34e932c56c1"
 dependencies = [
  "bs58",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -5140,15 +5356,15 @@ dependencies = [
  "bzip2",
  "enum-iterator",
  "flate2",
- "futures 0.3.24",
+ "futures 0.3.28",
  "goauth",
  "http",
  "hyper",
  "hyper-proxy",
  "log",
  "openssl",
- "prost 0.11.7",
- "prost-types 0.11.7",
+ "prost 0.11.8",
+ "prost-types 0.11.8",
  "serde",
  "serde_derive",
  "smpl_jwt",
@@ -5170,7 +5386,7 @@ checksum = "874bb4b45eaa051b26d2758316009afe417d6743ff5b2f92da59ae0b8bd77b80"
 dependencies = [
  "bincode",
  "bs58",
- "prost 0.11.7",
+ "prost 0.11.8",
  "protobuf-src",
  "serde",
  "solana-account-decoder",
@@ -5196,10 +5412,10 @@ dependencies = [
  "pem",
  "percentage",
  "pkcs8",
- "quinn",
+ "quinn 0.8.5",
  "rand 0.7.3",
  "rcgen",
- "rustls 0.20.6",
+ "rustls 0.20.8",
  "solana-metrics",
  "solana-perf",
  "solana-sdk",
@@ -5232,7 +5448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5bbdaed99403e4a17763bee60c1e0e3418524503c72b514ebff62efbcc9d33"
 dependencies = [
  "Inflector",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bincode",
  "borsh",
  "bs58",
@@ -5314,11 +5530,11 @@ checksum = "cebca4083e982ae01583d1a590c4d679e6f648a4761364ddfb43026d2c433142"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bincode",
  "bytemuck",
  "byteorder",
- "cipher 0.4.3",
+ "cipher 0.4.4",
  "curve25519-dalek",
  "getrandom 0.1.16",
  "itertools",
@@ -5363,9 +5579,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -5479,9 +5695,9 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.0",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "heck 0.4.1",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -5515,16 +5731,27 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "unicode-ident",
 ]
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -5532,10 +5759,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
- "unicode-xid 0.2.3",
+ "unicode-xid 0.2.4",
 ]
 
 [[package]]
@@ -5574,35 +5801,24 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi 0.3.9",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5616,35 +5832,35 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.33"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0a539a918745651435ac7db7a18761589a94cd7e94cd56999f828bf73c8a57"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.33"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
- "syn 1.0.109",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -5653,21 +5869,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.14"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
+ "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.4"
+name = "time-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tiny-bip39"
@@ -5699,9 +5924,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5735,20 +5960,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -5771,16 +5996,16 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.6",
+ "rustls 0.20.8",
  "tokio",
  "webpki 0.22.0",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5795,7 +6020,7 @@ checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.20.6",
+ "rustls 0.20.8",
  "tokio",
  "tokio-rustls 0.23.4",
  "tungstenite",
@@ -5834,11 +6059,28 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -5849,7 +6091,7 @@ checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5858,7 +6100,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-timeout",
- "percent-encoding 2.1.0",
+ "percent-encoding 2.2.0",
  "pin-project",
  "prost 0.9.0",
  "prost-derive 0.9.0",
@@ -5875,14 +6117,14 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.7.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.5.17",
- "base64 0.13.0",
+ "axum",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5891,12 +6133,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-timeout",
- "percent-encoding 2.1.0",
+ "percent-encoding 2.2.0",
  "pin-project",
- "prost 0.10.4",
- "prost-derive 0.10.1",
+ "prost 0.11.8",
+ "prost-derive 0.11.8",
  "rustls-native-certs",
- "rustls-pemfile 1.0.1",
+ "rustls-pemfile 1.0.2",
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-stream",
@@ -5910,61 +6152,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.7",
- "base64 0.13.0",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding 2.1.0",
- "pin-project",
- "prost 0.11.7",
- "prost-derive 0.11.7",
- "rustls-pemfile 1.0.1",
- "tokio",
- "tokio-rustls 0.23.4",
- "tokio-stream",
- "tokio-util 0.7.2",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
 name = "tonic-build"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.56",
  "prost-build 0.9.0",
- "quote 1.0.21",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9263bf4c9bfaae7317c1c2faf7f18491d2fe476f70c414b73bf5d445b00ffa1"
-dependencies = [
- "prettyplease",
- "proc-macro2 1.0.50",
- "prost-build 0.10.4",
- "quote 1.0.21",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -5975,9 +6170,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
- "proc-macro2 1.0.50",
- "prost-build 0.11.7",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "prost-build 0.11.8",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
@@ -6002,25 +6197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-http"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-layer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6034,9 +6210,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -6047,20 +6223,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
 ]
@@ -6083,9 +6259,9 @@ checksum = "0de5f738ceab88e2491a94ddc33c3feeadfa95fedc60363ef110845df12f3878"
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
@@ -6093,17 +6269,17 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.20.6",
- "sha-1 0.10.0",
+ "rustls 0.20.8",
+ "sha-1 0.10.1",
  "thiserror",
- "url 2.2.2",
+ "url 2.3.1",
  "utf-8",
  "webpki 0.22.0",
  "webpki-roots",
@@ -6111,15 +6287,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicase"
@@ -6132,36 +6308,36 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -6171,9 +6347,9 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
@@ -6232,14 +6408,13 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.3",
- "matches",
- "percent-encoding 2.1.0",
+ "idna 0.3.0",
+ "percent-encoding 2.2.0",
 ]
 
 [[package]]
@@ -6257,6 +6432,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vcpkg"
@@ -6284,12 +6465,11 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -6323,9 +6503,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -6333,24 +6513,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.32"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -6360,22 +6540,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
- "quote 1.0.21",
+ "quote 1.0.26",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
  "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -6383,15 +6563,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6419,18 +6599,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.4"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki 0.22.0",
 ]
 
 [[package]]
 name = "which"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
  "either",
  "libc",
@@ -6481,47 +6661,169 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.36.1"
+name = "windows"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
+name = "windows-sys"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -6539,7 +6841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
 dependencies = [
  "asn1-rs",
- "base64 0.13.0",
+ "base64 0.13.1",
  "data-encoding",
  "der-parser",
  "lazy_static",
@@ -6547,7 +6849,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.14",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -6570,11 +6872,11 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.14",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -6588,14 +6890,13 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.21",
- "syn 1.0.109",
- "synstructure",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -6619,10 +6920,11 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
+version = "2.0.8+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,7 +2261,6 @@ dependencies = [
  "log",
  "once_cell",
  "quinn 0.9.3",
- "rand 0.8.5",
  "rustls 0.20.8",
  "solana-client",
  "solana-net-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,6 +2258,7 @@ dependencies = [
  "clap 4.2.1",
  "env_logger",
  "futures-util",
+ "itertools",
  "log",
  "once_cell",
  "quinn 0.9.3",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,41 @@
 # syntax=docker/dockerfile:1.4.0
-FROM rust:1.62.1-slim-buster as builder
+FROM rust:1.66.0-slim-bullseye as builder
 
-RUN apt-get update && apt-get install -y libudev-dev clang pkg-config libssl-dev build-essential cmake
-RUN rustup component add rustfmt
-RUN update-ca-certificates
+RUN set -x \
+    && apt-get -qq update \
+    && apt-get -qq -y install \
+    clang \
+    cmake \
+    libudev-dev \
+    unzip \
+    libssl-dev \
+    pkg-config \
+    zlib1g-dev \
+    curl
+RUN rustup component add rustfmt && update-ca-certificates
+
+ENV PROTOC_VERSION 21.12
+ENV PROTOC_ZIP protoc-$PROTOC_VERSION-linux-x86_64.zip
+RUN curl -Ss -OL https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP \
+ && unzip -o $PROTOC_ZIP -d /usr/local bin/protoc \
+ && unzip -o $PROTOC_ZIP -d /usr/local include/* \
+ && rm -f $PROTOC_ZIP
 
 ENV HOME=/home/root
 WORKDIR $HOME/app
 COPY . .
 
+# cache these directories for reuse
+# see: https://docs.docker.com/build/cache/#use-the-dedicated-run-cache
 RUN --mount=type=cache,mode=0777,target=/home/root/app/target \
     --mount=type=cache,mode=0777,target=/usr/local/cargo/registry \
-    cargo build --release && cp target/release/jito-* ./
+    --mount=type=cache,mode=0777,target=/usr/local/cargo/git \
+    RUSTFLAGS="-C target-cpu=native" cargo build --release && cp target/release/jito-* ./
 
-FROM debian:buster-slim as jito-transaction-relayer
-
-# needed for HTTPS
-RUN \
-  apt-get update && \
-  apt-get -y install ca-certificates && \
-  apt-get clean
+FROM debian:bullseye-slim as jito-transaction-relayer
+RUN apt-get -qq update && apt-get -qq -y install ca-certificates libssl1.1 && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY --from=builder /home/root/app/jito-transaction-relayer ./
+COPY --from=builder /home/root/app/jito-packet-blaster ./
 ENTRYPOINT ./jito-transaction-relayer

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cargo b --release
 
 ## Generate RSA keys:
 One needs to generate RSA keys for JWT key generation and verification. To do that, use the following scripts:
-```asm
+```bash
 OUTPUT_DIR=
 openssl genrsa --out $OUTPUT_DIR/private.pem
 openssl rsa --in $OUTPUT_DIR/private.pem --pubout --out $OUTPUT_DIR/public.pem

--- a/b
+++ b/b
@@ -1,40 +1,23 @@
-#!/usr/bin/env sh
-set -e
+#!/usr/bin/env bash
+set -euxo pipefail
 
 TAG=$(git describe --match=NeVeRmAtCh --always --abbrev=8 --dirty)
 ORG="jitolabs"
 
-if [ "$(uname)" = "Darwin" ]; then
-    RPC_SERVERS=http://docker.for.mac.localhost:8899
-    WEBSOCKET_SERVERS=ws://docker.for.mac.localhost:8900
-    BLOCK_ENGINE_AUTH_SERVICE_URL=http://docker.for.mac.localhost:1005
-    BLOCK_ENGINE_URL=http://docker.for.mac.localhost:1000
-  elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
-    RPC_SERVERS=http://172.17.0.1:8899
-    WEBSOCKET_SERVERS=ws://172.17.0.1:8900
-    BLOCK_ENGINE_AUTH_SERVICE_URL=http://172.17.0.1:1005
-    BLOCK_ENGINE_URL=http://172.17.0.1:1000
-  else
-    echo "unsupported testing platform, exiting"
-    exit 1
-  fi
+export DOCKER_LOCALHOST=172.17.0.1
+if [[ $(uname) == "Darwin" ]]; then
+  DOCKER_LOCALHOST=docker.for.mac.localhost
+fi
 
-COMPOSE_DOCKER_CLI_BUILD=1 \
-  DOCKER_BUILDKIT=1 \
-  RPC_SERVERS="${RPC_SERVERS}" \
-  WEBSOCKET_SERVERS="${WEBSOCKET_SERVERS}" \
-  BLOCK_ENGINE_URL="${BLOCK_ENGINE_URL}" \
-  BLOCK_ENGINE_AUTH_SERVICE_URL="${BLOCK_ENGINE_AUTH_SERVICE_URL}" \
+# Build and run
+DOCKER_BUILDKIT=1 \
+  BUILDKIT_PROGRESS=plain \
   TAG="${TAG}" \
   ORG="${ORG}" \
-  docker compose --env-file "${ENV_FILE}" build --progress=plain
-
-COMPOSE_DOCKER_CLI_BUILD=1 \
-  DOCKER_BUILDKIT=1 \
-  RPC_SERVERS="${RPC_SERVERS}" \
-  WEBSOCKET_SERVERS="${WEBSOCKET_SERVERS}" \
-  BLOCK_ENGINE_URL="${BLOCK_ENGINE_URL}" \
-  BLOCK_ENGINE_AUTH_SERVICE_URL="${BLOCK_ENGINE_AUTH_SERVICE_URL}" \
-  TAG="${TAG}" \
-  ORG="${ORG}" \
-  docker compose --env-file "${ENV_FILE}" up --remove-orphans
+  RPC_SERVERS=http://${DOCKER_LOCALHOST}:8899 \
+  WEBSOCKET_SERVERS=ws://${DOCKER_LOCALHOST}:8900 \
+  BLOCK_ENGINE_AUTH_SERVICE_URL=http://${DOCKER_LOCALHOST}:1005 \
+  BLOCK_ENGINE_URL=http://${DOCKER_LOCALHOST}:1000 \
+  CLUSTER=devnet \
+  REGION=local \
+  docker compose up --build --pull=always --remove-orphans --renew-anon-volumes

--- a/b
+++ b/b
@@ -4,6 +4,11 @@ set -euxo pipefail
 TAG=$(git describe --match=NeVeRmAtCh --always --abbrev=8 --dirty)
 ORG="jitolabs"
 
+if [[ ! $(uname) =~ ^(Linux|Darwin)$ ]]; then
+    echo "unsupported os found"
+    exit 1
+fi
+
 export DOCKER_LOCALHOST=172.17.0.1
 if [[ $(uname) == "Darwin" ]]; then
   DOCKER_LOCALHOST=docker.for.mac.localhost

--- a/block_engine/Cargo.toml
+++ b/block_engine/Cargo.toml
@@ -12,11 +12,11 @@ cached = "0.42.0"
 dashmap = "5.4.0"
 jito-protos = { path = "../jito-protos" }
 log = "0.4.17"
-prost-types = "0.10.1"
+prost-types = "0.11.8"
 solana-metrics = "=1.14.13"
 solana-perf = "=1.14.13"
 solana-sdk = "=1.14.13"
-thiserror = "1.0.31"
-tokio = { version = "1.14.1", features = ["full"] }
-tokio-stream = "0.1.9"
-tonic = { version = "0.7.2", features = ["tls", "tls-roots", "tls-webpki-roots"] }
+thiserror = "1.0.40"
+tokio = { version = "~1.14.1", features = ["rt-multi-thread"] }
+tokio-stream = "0.1.12"
+tonic = { version = "0.8.3", features = ["tls", "tls-roots", "tls-webpki-roots"] }

--- a/block_engine/src/block_engine.rs
+++ b/block_engine/src/block_engine.rs
@@ -107,7 +107,7 @@ impl BlockEngineRelayerHandler {
         keypair: Arc<Keypair>,
         exit: Arc<AtomicBool>,
         aoi_cache_ttl_s: u64,
-        address_lookup_table_cache: DashMap<Pubkey, AddressLookupTableAccount>,
+        address_lookup_table_cache: Arc<DashMap<Pubkey, AddressLookupTableAccount>>,
     ) -> BlockEngineRelayerHandler {
         let block_engine_forwarder = Builder::new()
             .name("block_engine_relayer_handler_thread".into())

--- a/block_engine/src/block_engine.rs
+++ b/block_engine/src/block_engine.rs
@@ -97,53 +97,20 @@ pub struct BlockEngineRelayerHandler {
 }
 
 impl BlockEngineRelayerHandler {
+    const BLOCK_ENGINE_PACKET_QUEUE_CAPACITY: usize = 1_000;
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         block_engine_url: String,
         auth_service_url: String,
-        block_engine_receiver: Receiver<BlockEnginePackets>,
+        mut block_engine_receiver: Receiver<BlockEnginePackets>,
         keypair: Arc<Keypair>,
-        exit: &Arc<AtomicBool>,
-        cluster: String,
-        region: String,
+        exit: Arc<AtomicBool>,
         aoi_cache_ttl_s: u64,
         address_lookup_table_cache: DashMap<Pubkey, AddressLookupTableAccount>,
     ) -> BlockEngineRelayerHandler {
-        let block_engine_forwarder = Self::start_block_engine_relayer_stream(
-            block_engine_url,
-            auth_service_url,
-            block_engine_receiver,
-            keypair,
-            exit,
-            cluster,
-            region,
-            aoi_cache_ttl_s,
-            address_lookup_table_cache,
-        );
-        BlockEngineRelayerHandler {
-            block_engine_forwarder,
-        }
-    }
-
-    pub fn join(self) -> thread::Result<()> {
-        self.block_engine_forwarder.join()
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn start_block_engine_relayer_stream(
-        block_engine_url: String,
-        auth_service_url: String,
-        mut block_engine_receiver: Receiver<BlockEnginePackets>,
-        keypair: Arc<Keypair>,
-        exit: &Arc<AtomicBool>,
-        cluster: String,
-        region: String,
-        aoi_cache_ttl_s: u64,
-        address_lookup_table_cache: DashMap<Pubkey, AddressLookupTableAccount>,
-    ) -> JoinHandle<()> {
-        let exit = exit.clone();
-        Builder::new()
-            .name("jito_block_engine_relayer_stream".into())
+        let block_engine_forwarder = Builder::new()
+            .name("block_engine_relayer_handler_thread".into())
             .spawn(move || {
                 let rt = Runtime::new().unwrap();
                 rt.block_on(async move {
@@ -154,8 +121,6 @@ impl BlockEngineRelayerHandler {
                             &mut block_engine_receiver,
                             &keypair,
                             &exit,
-                            &cluster,
-                            &region,
                             aoi_cache_ttl_s,
                             &address_lookup_table_cache,
                         )
@@ -167,8 +132,6 @@ impl BlockEngineRelayerHandler {
                                 datapoint_error!("block_engine_relayer-error",
                                     "block_engine_url" => block_engine_url,
                                     "auth_service_url" => auth_service_url,
-                                    "cluster" => &cluster,
-                                    "region" => &region,
                                     ("error", e.to_string(), String)
                                 );
                                 sleep(Duration::from_secs(2)).await;
@@ -177,7 +140,14 @@ impl BlockEngineRelayerHandler {
                     }
                 });
             })
-            .unwrap()
+            .unwrap();
+        BlockEngineRelayerHandler {
+            block_engine_forwarder,
+        }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.block_engine_forwarder.join()
     }
 
     /// Relayers are whitelisted in the block engine. In order to auth, a challenge-response handshake
@@ -240,8 +210,6 @@ impl BlockEngineRelayerHandler {
         block_engine_receiver: &mut Receiver<BlockEnginePackets>,
         keypair: &Arc<Keypair>,
         exit: &Arc<AtomicBool>,
-        cluster: &str,
-        region: &str,
         aoi_cache_ttl_s: u64,
         address_lookup_table_cache: &DashMap<Pubkey, AddressLookupTableAccount>,
     ) -> BlockEngineResult<()> {
@@ -292,8 +260,6 @@ impl BlockEngineRelayerHandler {
         datapoint_info!("block_engine-connection_stats",
             "block_engine_url" => block_engine_url,
             "auth_service_url" => auth_service_url,
-            "cluster" => cluster,
-            "region" => region,
             ("connected", 1, i64)
         );
 
@@ -307,8 +273,6 @@ impl BlockEngineRelayerHandler {
             &mut refresh_token,
             shared_access_token,
             exit,
-            String::from(cluster),
-            String::from(region),
             aoi_cache_ttl_s,
             address_lookup_table_cache,
         )
@@ -329,8 +293,6 @@ impl BlockEngineRelayerHandler {
         refresh_token: &mut Token,
         shared_access_token: Arc<Mutex<Token>>,
         exit: &Arc<AtomicBool>,
-        cluster: String,
-        region: String,
         aoi_cache_ttl_s: u64,
         address_lookup_table_cache: &DashMap<Pubkey, AddressLookupTableAccount>,
     ) -> BlockEngineResult<()> {
@@ -342,14 +304,17 @@ impl BlockEngineRelayerHandler {
             .subscribe_programs_of_interest(ProgramsOfInterestRequest {})
             .await
             .map_err(|e| BlockEngineError::BlockEngineFailure(e.to_string()))?;
-        let (packet_msg_sender, packet_msg_receiver) = channel(1_000);
+
+        // sender tracked as block_engine_relayer-loop_stats.block_engine_packet_sender_len
+        let (block_engine_packet_sender, block_engine_packet_receiver) =
+            channel(Self::BLOCK_ENGINE_PACKET_QUEUE_CAPACITY);
         let _response = client
-            .start_expiring_packet_stream(ReceiverStream::new(packet_msg_receiver))
+            .start_expiring_packet_stream(ReceiverStream::new(block_engine_packet_receiver))
             .await
             .map_err(|e| BlockEngineError::BlockEngineFailure(e.to_string()))?;
 
         Self::handle_packet_stream(
-            packet_msg_sender,
+            block_engine_packet_sender,
             block_engine_receiver,
             subscribe_aoi_stream,
             subscribe_poi_stream,
@@ -358,8 +323,6 @@ impl BlockEngineRelayerHandler {
             refresh_token,
             shared_access_token,
             exit,
-            cluster,
-            region,
             aoi_cache_ttl_s,
             address_lookup_table_cache,
         )
@@ -377,8 +340,6 @@ impl BlockEngineRelayerHandler {
         refresh_token: &mut Token,
         shared_access_token: Arc<Mutex<Token>>,
         exit: &Arc<AtomicBool>,
-        cluster: String,
-        region: String,
         aoi_cache_ttl_s: u64,
         address_lookup_table_cache: &DashMap<Pubkey, AddressLookupTableAccount>,
     ) -> BlockEngineResult<()> {
@@ -396,14 +357,14 @@ impl BlockEngineRelayerHandler {
 
         let mut block_engine_stats = BlockEngineStats::default();
 
-        let mut heartbeat = interval(Duration::from_millis(500));
-        let mut refresh_interval = interval(Duration::from_secs(60));
+        let mut heartbeat_interval = interval(Duration::from_millis(500));
+        let mut auth_refresh_interval = interval(Duration::from_secs(60));
         let mut metrics_interval = interval(Duration::from_secs(1));
 
         let mut heartbeat_count = 0;
         while !exit.load(Ordering::Relaxed) {
             select! {
-                _ = heartbeat.tick() => {
+                _ = heartbeat_interval.tick() => {
                     trace!("sending heartbeat");
 
                     let now = Instant::now();
@@ -445,16 +406,16 @@ impl BlockEngineRelayerHandler {
                     let now = Instant::now();
                     block_engine_stats.increment_num_packets_received(block_engine_batches.packet_batches.iter().map(|b|b.len() as u64).sum::<u64>());
                     let filtered_packets = Self::filter_packets(block_engine_batches, &mut accounts_of_interest, &mut programs_of_interest, address_lookup_table_cache);
-                    block_engine_stats.increment_packet_filter_elapsed(now.elapsed().as_micros() as u64);
+                    block_engine_stats.increment_packet_filter_elapsed_us(now.elapsed().as_micros() as u64);
 
                     if let Some(filtered_packets) = filtered_packets {
                         let now = Instant::now();
                         let packet_forward_count = Self::forward_packets(&block_engine_packet_sender, filtered_packets).await?;
                         block_engine_stats.increment_packet_forward_count(packet_forward_count as u64);
-                        block_engine_stats.increment_packet_forward_elapsed(now.elapsed().as_micros() as u64);
+                        block_engine_stats.increment_packet_forward_elapsed_us(now.elapsed().as_micros() as u64);
                     }
                 }
-                _ = refresh_interval.tick() => {
+                _ = auth_refresh_interval.tick() => {
                     trace!("refreshing auth interval");
                     let now = Instant::now();
 
@@ -475,11 +436,17 @@ impl BlockEngineRelayerHandler {
 
                     block_engine_stats.increment_flush_elapsed_us(flush_start.elapsed().as_micros() as u64);
                     block_engine_stats.increment_accounts_of_interest_len(accounts_of_interest.cache_size() as u64);
+                    block_engine_stats.increment_programs_of_interest_len(programs_of_interest.cache_size() as u64);
 
-                    block_engine_stats.report(&cluster, &region);
+                    block_engine_stats.report();
                     block_engine_stats = BlockEngineStats::default();
                 }
             }
+
+            block_engine_stats.update_block_engine_packet_sender_len(
+                (Self::BLOCK_ENGINE_PACKET_QUEUE_CAPACITY - block_engine_packet_sender.capacity())
+                    as u64,
+            );
         }
         Ok(())
     }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-crossbeam-channel = "0.5.4"
+crossbeam-channel = "0.5.7"
 jito-rpc = { path = "../rpc" }
 lazy_static = "1.4.0"
 log = "0.4.17"
-rayon = "1.5.3"
+rayon = "1.7.0"
 solana-client = "=1.14.13"
 solana-core = "=1.14.13"
 solana-gossip = "=1.14.13"
@@ -23,6 +23,6 @@ solana-rayon-threadlimit = "=1.14.13"
 solana-runtime = "=1.14.13"
 solana-sdk = "=1.14.13"
 solana-streamer = "=1.14.13"
-thiserror = "1.0.31"
-tokio = { version = "1.14.1", features = ["rt-multi-thread"] }
-tokio-stream = "0.1.9"
+thiserror = "1.0.40"
+tokio = { version = "~1.14.1", features = ["rt-multi-thread"] }
+tokio-stream = "0.1.12"

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -59,12 +59,18 @@ impl FetchStage {
                     if start.elapsed() >= metrics_interval {
                         datapoint_info!(
                             "fetch_stage-channel_stats",
+                            ("tpu_sender_len", tpu_sender_max_len, i64),
+                            ("tpu_sender_capacity", tpu_sender.capacity().unwrap(), i64),
                             (
-                                "tpu_forwards_receiver-len",
+                                "tpu_forwards_receiver_len",
                                 tpu_forwards_receiver_max_len,
                                 i64
                             ),
-                            ("tpu_sender-len", tpu_sender_max_len, i64),
+                            (
+                                "tpu_forwards_receiver_capacity",
+                                tpu_forwards_receiver.capacity().unwrap(),
+                                i64
+                            ),
                         );
                         start = Instant::now();
                         tpu_forwards_receiver_max_len = 0;

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -6,53 +6,99 @@ use std::{
         Arc,
     },
     thread::{self, Builder, JoinHandle},
+    time::{Duration, Instant},
 };
 
-use crossbeam_channel::{RecvError, RecvTimeoutError};
+use crossbeam_channel::{RecvError, RecvTimeoutError, SendError};
+use solana_metrics::{datapoint_error, datapoint_info};
+use solana_perf::packet::PacketBatch;
 use solana_sdk::packet::{Packet, PacketFlags};
 use solana_streamer::streamer::{PacketBatchReceiver, PacketBatchSender};
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("send error")]
-    Send,
-    #[error("recv timeout")]
+pub enum FetchStageError {
+    #[error("send error: {0}")]
+    Send(#[from] SendError<PacketBatch>),
+    #[error("recv timeout: {0}")]
     RecvTimeout(#[from] RecvTimeoutError),
-    #[error("recv error")]
+    #[error("recv error: {0}")]
     Recv(#[from] RecvError),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type FetchStageResult<T> = Result<T, FetchStageError>;
 
 pub struct FetchStage {
     thread_hdls: Vec<JoinHandle<()>>,
 }
 
 impl FetchStage {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_with_sender(
-        exit: &Arc<AtomicBool>,
-        forward_sender: &PacketBatchSender,
-        forward_receiver: PacketBatchReceiver,
+    pub fn new(
+        tpu_forwards_receiver: PacketBatchReceiver,
+        tpu_sender: PacketBatchSender,
+        exit: Arc<AtomicBool>,
     ) -> Self {
-        Self::new_fwd_thread(exit, forward_sender, forward_receiver)
+        let fwd_thread_hdl = Builder::new()
+            .name("fetch_stage-forwarder_thread".to_string())
+            .spawn(move || {
+                let metrics_interval = Duration::from_secs(1);
+                let mut start = Instant::now();
+                let mut tpu_forwards_receiver_max_len = 0usize;
+                let mut tpu_sender_max_len = 0usize;
+                while !exit.load(Ordering::Relaxed) {
+                    match Self::handle_forwarded_packets(&tpu_forwards_receiver, &tpu_sender) {
+                        Ok(()) | Err(FetchStageError::RecvTimeout(RecvTimeoutError::Timeout)) => {}
+                        Err(e) => {
+                            datapoint_error!(
+                                "fetch_stage-handle_forwarded_packets_error",
+                                ("error", e.to_string(), String)
+                            );
+                            panic!("Failed to handle forwarded packets. Error: {e}")
+                        }
+                    };
+
+                    if start.elapsed() >= metrics_interval {
+                        datapoint_info!(
+                            "fetch_stage-channel_stats",
+                            (
+                                "tpu_forwards_receiver-len",
+                                tpu_forwards_receiver_max_len,
+                                i64
+                            ),
+                            ("tpu_sender-len", tpu_sender_max_len, i64),
+                        );
+                        start = Instant::now();
+                        tpu_forwards_receiver_max_len = 0;
+                        tpu_sender_max_len = 0;
+                    }
+                    tpu_forwards_receiver_max_len =
+                        std::cmp::max(tpu_forwards_receiver_max_len, tpu_forwards_receiver.len());
+                    tpu_sender_max_len = std::cmp::max(tpu_sender_max_len, tpu_sender.len());
+                }
+            })
+            .unwrap();
+
+        Self {
+            thread_hdls: vec![fwd_thread_hdl],
+        }
     }
 
+    /// Copies tpu_forward packets to tpu channel. marks as forwarded
     fn handle_forwarded_packets(
-        recvr: &PacketBatchReceiver,
-        sendr: &PacketBatchSender,
-    ) -> Result<()> {
+        tpu_forwards_receiver: &PacketBatchReceiver,
+        tpu_sender: &PacketBatchSender,
+    ) -> FetchStageResult<()> {
         let mark_forwarded = |packet: &mut Packet| {
             packet.meta.flags |= PacketFlags::FORWARDED;
         };
 
-        let mut packet_batch = recvr.recv()?;
+        let mut packet_batch = tpu_forwards_receiver.recv()?;
         let mut num_packets = packet_batch.len();
         packet_batch.iter_mut().for_each(mark_forwarded);
+
         let mut packet_batches = vec![packet_batch];
-        while let Ok(mut packet_batch) = recvr.try_recv() {
-            packet_batch.iter_mut().for_each(mark_forwarded);
+        while let Ok(mut packet_batch) = tpu_forwards_receiver.try_recv() {
             num_packets += packet_batch.len();
+            packet_batch.iter_mut().for_each(mark_forwarded);
             packet_batches.push(packet_batch);
             // Read at most 1K transactions in a loop
             if num_packets > 1024 {
@@ -61,45 +107,12 @@ impl FetchStage {
         }
 
         for packet_batch in packet_batches {
-            #[allow(clippy::question_mark)]
-            if sendr.send(packet_batch).is_err() {
-                return Err(Error::Send);
+            if let Err(e) = tpu_sender.send(packet_batch) {
+                return Err(FetchStageError::Send(e));
             }
         }
 
         Ok(())
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn new_fwd_thread(
-        exit: &Arc<AtomicBool>,
-        sender: &PacketBatchSender,
-        forward_receiver: PacketBatchReceiver,
-    ) -> Self {
-        let sender = sender.clone();
-
-        let fwd_thread_hdl = {
-            let exit = exit.clone();
-            Builder::new()
-                .name("solana-fetch-stage-fwd-rcvr".to_string())
-                .spawn(move || {
-                    while !exit.load(Ordering::Relaxed) {
-                        if let Err(e) = Self::handle_forwarded_packets(&forward_receiver, &sender) {
-                            match e {
-                                Error::RecvTimeout(RecvTimeoutError::Disconnected) => break,
-                                Error::RecvTimeout(RecvTimeoutError::Timeout) => (),
-                                Error::Recv(_) => break,
-                                Error::Send => break,
-                            }
-                        }
-                    }
-                })
-                .unwrap()
-        };
-
-        Self {
-            thread_hdls: vec![fwd_thread_hdl],
-        }
     }
 
     pub fn join(self) -> thread::Result<()> {

--- a/core/src/staked_nodes_updater_service.rs
+++ b/core/src/staked_nodes_updater_service.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Mutex, RwLock,
+        Arc, RwLock,
     },
     thread::{self, sleep, Builder, JoinHandle},
     time::{Duration, Instant},
@@ -24,11 +24,11 @@ pub struct StakedNodesUpdaterService {
 impl StakedNodesUpdaterService {
     pub fn new(
         exit: Arc<AtomicBool>,
-        rpc_load_balancer: Arc<Mutex<LoadBalancer>>,
+        rpc_load_balancer: Arc<LoadBalancer>,
         shared_staked_nodes: Arc<RwLock<StakedNodes>>,
     ) -> Self {
         let thread_hdl = Builder::new()
-            .name("sol-sn-updater".to_string())
+            .name("staked_nodes_updater_thread".to_string())
             .spawn(move || {
                 let mut last_stakes = Instant::now();
                 while !exit.load(Ordering::Relaxed) {
@@ -59,10 +59,10 @@ impl StakedNodesUpdaterService {
         ip_to_stake: &mut HashMap<IpAddr, u64>,
         pubkey_stake_map: &mut HashMap<Pubkey, u64>,
         total_stake: &mut u64,
-        rpc_load_balancer: &Arc<Mutex<LoadBalancer>>,
+        rpc_load_balancer: &Arc<LoadBalancer>,
     ) -> client_error::Result<bool> {
         if last_stakes.elapsed() > IP_TO_STAKE_REFRESH_DURATION {
-            let client = rpc_load_balancer.lock().unwrap().rpc_client();
+            let client = rpc_load_balancer.rpc_client();
             let vote_accounts = client.get_vote_accounts()?;
             let cluster_info: HashMap<String, RpcContactInfo> = client
                 .get_cluster_nodes()?

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -3,17 +3,23 @@
 
 use std::{
     net::{IpAddr, UdpSocket},
-    sync::{atomic::AtomicBool, Arc, Mutex, RwLock},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock,
+    },
     thread,
-    thread::JoinHandle,
+    thread::{sleep, Builder, JoinHandle},
+    time::Duration,
 };
 
-use crossbeam_channel::{unbounded, Receiver};
+use crossbeam_channel::Receiver;
 use jito_rpc::load_balancer::LoadBalancer;
 use solana_core::{
     banking_stage::BankingPacketBatch, find_packet_sender_stake_stage::FindPacketSenderStakeStage,
     sigverify::TransactionSigVerifier, sigverify_stage::SigVerifyStage,
 };
+use solana_metrics::datapoint_info;
+use solana_perf::packet::PacketBatch;
 use solana_sdk::signature::Keypair;
 use solana_streamer::{
     quic::{spawn_server, StreamStats, MAX_STAKED_CONNECTIONS, MAX_UNSTAKED_CONNECTIONS},
@@ -27,6 +33,7 @@ pub const DEFAULT_TPU_COALESCE_MS: u64 = 5;
 // allow multiple connections for NAT and any open/close overlap
 pub const MAX_QUIC_CONNECTIONS_PER_IP: usize = 8;
 
+#[derive(Debug)]
 pub struct TpuSockets {
     pub transactions_quic_sockets: UdpSocket,
     pub transactions_forwards_quic_sockets: UdpSocket,
@@ -37,29 +44,24 @@ pub struct Tpu {
     staked_nodes_updater_service: StakedNodesUpdaterService,
     find_packet_sender_stake_stage: FindPacketSenderStakeStage,
     sigverify_stage: SigVerifyStage,
-    tpu_quic_t: JoinHandle<()>,
-    tpu_forwards_quic_t: JoinHandle<()>,
+    thread_handles: Vec<JoinHandle<()>>,
 }
 
 impl Tpu {
+    pub const TPU_QUEUE_CAPACITY: usize = 10_000;
+
     pub fn new(
         sockets: TpuSockets,
         exit: &Arc<AtomicBool>,
         keypair: &Keypair,
         tpu_ip: &IpAddr,
         tpu_fwd_ip: &IpAddr,
-        rpc_load_balancer: &Arc<Mutex<LoadBalancer>>,
+        rpc_load_balancer: &Arc<LoadBalancer>,
     ) -> (Self, Receiver<BankingPacketBatch>) {
         let TpuSockets {
             transactions_quic_sockets,
             transactions_forwards_quic_sockets,
         } = sockets;
-
-        let (packet_sender, packet_receiver) = unbounded();
-        let (forwarded_packet_sender, forwarded_packet_receiver) = unbounded();
-
-        let fetch_stage =
-            FetchStage::new_with_sender(exit, &packet_sender, forwarded_packet_receiver);
 
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let staked_nodes_updater_service = StakedNodesUpdaterService::new(
@@ -68,21 +70,19 @@ impl Tpu {
             staked_nodes.clone(),
         );
 
-        let (find_packet_sender_stake_sender, find_packet_sender_stake_receiver) = unbounded();
+        // sender tracked as fetch_stage-channel_stats.tpu_sender-len
+        let (tpu_sender, tpu_receiver) = crossbeam_channel::bounded(Tpu::TPU_QUEUE_CAPACITY);
 
-        let find_packet_sender_stake_stage = FindPacketSenderStakeStage::new(
-            packet_receiver,
-            find_packet_sender_stake_sender,
-            staked_nodes.clone(),
-            "tpu-find-packet-sender-stake",
-        );
-
+        // receiver tracked as fetch_stage-channel_stats.tpu_forwards_receiver-len
+        let (tpu_forwards_sender, tpu_forwards_receiver) =
+            crossbeam_channel::bounded(Tpu::TPU_QUEUE_CAPACITY);
         let stats = Arc::new(StreamStats::default());
+
         let tpu_quic_t = spawn_server(
             transactions_quic_sockets,
             keypair,
             *tpu_ip,
-            packet_sender,
+            tpu_sender.clone(),
             exit.clone(),
             MAX_QUIC_CONNECTIONS_PER_IP,
             staked_nodes.clone(),
@@ -96,22 +96,39 @@ impl Tpu {
             transactions_forwards_quic_sockets,
             keypair,
             *tpu_fwd_ip,
-            forwarded_packet_sender,
+            tpu_forwards_sender,
             exit.clone(),
             MAX_QUIC_CONNECTIONS_PER_IP,
-            staked_nodes,
+            staked_nodes.clone(),
             MAX_STAKED_CONNECTIONS.saturating_add(MAX_UNSTAKED_CONNECTIONS),
             0, // Prevent unstaked nodes from forwarding transactions
             stats,
         )
         .unwrap();
 
-        let (verified_sender, verified_receiver) = unbounded();
+        let fetch_stage = FetchStage::new(tpu_forwards_receiver, tpu_sender, exit.clone());
 
-        let sigverify_stage = {
-            let verifier = TransactionSigVerifier::new(verified_sender);
-            SigVerifyStage::new(find_packet_sender_stake_receiver, verifier, "tpu-verifier")
-        };
+        // receiver tracked in tpu-channel_stats.find_packet_sender_stake_receiver-len
+        let (find_packet_sender_stake_sender, find_packet_sender_stake_receiver) =
+            crossbeam_channel::bounded(Self::TPU_QUEUE_CAPACITY);
+        let find_packet_sender_stake_stage = FindPacketSenderStakeStage::new(
+            tpu_receiver,
+            find_packet_sender_stake_sender,
+            staked_nodes,
+            "tpu_find_packet_sender_stake-stats",
+        );
+
+        let metrics_t =
+            Self::start_metrics_thread(exit.clone(), find_packet_sender_stake_receiver.clone());
+
+        // receiver tracked as forwarder_metrics.verified_receiver-len
+        let (verified_sender, verified_receiver) =
+            crossbeam_channel::bounded(Self::TPU_QUEUE_CAPACITY);
+        let sigverify_stage = SigVerifyStage::new(
+            find_packet_sender_stake_receiver,
+            TransactionSigVerifier::new(verified_sender),
+            "tpu-verifier",
+        );
 
         (
             Tpu {
@@ -119,11 +136,34 @@ impl Tpu {
                 staked_nodes_updater_service,
                 find_packet_sender_stake_stage,
                 sigverify_stage,
-                tpu_quic_t,
-                tpu_forwards_quic_t,
+                thread_handles: vec![tpu_quic_t, tpu_forwards_quic_t, metrics_t],
             },
             verified_receiver,
         )
+    }
+
+    // channel consumed by solana code, receiver tracked in tpu-channel_stats.find_packet_sender_stake_receiver-len
+    fn start_metrics_thread(
+        exit: Arc<AtomicBool>,
+        find_packet_sender_stake_receiver: Receiver<Vec<PacketBatch>>,
+    ) -> JoinHandle<()> {
+        Builder::new()
+            .name("tpu_metrics_thread".to_string())
+            .spawn(move || {
+                let metrics_interval = Duration::from_secs(1);
+                while !exit.load(Ordering::Relaxed) {
+                    datapoint_info!(
+                        "tpu-channel_stats",
+                        (
+                            "find_packet_sender_stake_receiver-len",
+                            find_packet_sender_stake_receiver.len(),
+                            i64
+                        ),
+                    );
+                    sleep(metrics_interval);
+                }
+            })
+            .unwrap()
     }
 
     pub fn join(self) -> thread::Result<()> {
@@ -131,8 +171,9 @@ impl Tpu {
         self.staked_nodes_updater_service.join()?;
         self.find_packet_sender_stake_stage.join()?;
         self.sigverify_stage.join()?;
-        self.tpu_quic_t.join()?;
-        self.tpu_forwards_quic_t.join()?;
+        for t in self.thread_handles {
+            t.join()?
+        }
         Ok(())
     }
 }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -70,10 +70,10 @@ impl Tpu {
             staked_nodes.clone(),
         );
 
-        // sender tracked as fetch_stage-channel_stats.tpu_sender-len
+        // sender tracked as fetch_stage-channel_stats.tpu_sender_len
         let (tpu_sender, tpu_receiver) = crossbeam_channel::bounded(Tpu::TPU_QUEUE_CAPACITY);
 
-        // receiver tracked as fetch_stage-channel_stats.tpu_forwards_receiver-len
+        // receiver tracked as fetch_stage-channel_stats.tpu_forwards_receiver_len
         let (tpu_forwards_sender, tpu_forwards_receiver) =
             crossbeam_channel::bounded(Tpu::TPU_QUEUE_CAPACITY);
         let stats = Arc::new(StreamStats::default());
@@ -108,7 +108,7 @@ impl Tpu {
 
         let fetch_stage = FetchStage::new(tpu_forwards_receiver, tpu_sender, exit.clone());
 
-        // receiver tracked in tpu-channel_stats.find_packet_sender_stake_receiver-len
+        // receiver tracked in tpu-channel_stats.find_packet_sender_stake_receiver_len
         let (find_packet_sender_stake_sender, find_packet_sender_stake_receiver) =
             crossbeam_channel::bounded(Self::TPU_QUEUE_CAPACITY);
         let find_packet_sender_stake_stage = FindPacketSenderStakeStage::new(
@@ -121,7 +121,7 @@ impl Tpu {
         let metrics_t =
             Self::start_metrics_thread(exit.clone(), find_packet_sender_stake_receiver.clone());
 
-        // receiver tracked as forwarder_metrics.verified_receiver-len
+        // receiver tracked as forwarder_metrics.verified_receiver_len
         let (verified_sender, verified_receiver) =
             crossbeam_channel::bounded(Self::TPU_QUEUE_CAPACITY);
         let sigverify_stage = SigVerifyStage::new(
@@ -142,7 +142,7 @@ impl Tpu {
         )
     }
 
-    // channel consumed by solana code, receiver tracked in tpu-channel_stats.find_packet_sender_stake_receiver-len
+    // channel consumed by solana code, receiver tracked in tpu-channel_stats.find_packet_sender_stake_receiver_len
     fn start_metrics_thread(
         exit: Arc<AtomicBool>,
         find_packet_sender_stake_receiver: Receiver<Vec<PacketBatch>>,
@@ -155,8 +155,13 @@ impl Tpu {
                     datapoint_info!(
                         "tpu-channel_stats",
                         (
-                            "find_packet_sender_stake_receiver-len",
+                            "find_packet_sender_stake_receiver_len",
                             find_packet_sender_stake_receiver.len(),
+                            i64
+                        ),
+                        (
+                            "find_packet_sender_stake_receiver_capacity",
+                            find_packet_sender_stake_receiver.capacity().unwrap(),
                             i64
                         ),
                     );

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,8 @@ services:
       - VERIFYING_KEY_PEM_PATH=/etc/keys/public.pem
       - BLOCK_ENGINE_AUTH_SERVICE_URL=$BLOCK_ENGINE_AUTH_SERVICE_URL
       - BLOCK_ENGINE_URL=$BLOCK_ENGINE_URL
+      - CLUSTER=$CLUSTER
+      - REGION=$REGION
     restart: on-failure
     volumes:
       - ./config/keys:/etc/keys

--- a/f
+++ b/f
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Builds relayer in a docker container.
+# Useful for running on machines that might not have cargo installed but can run docker (Flatcar Linux).
+# run `./f ` to compile
+
+set -eux -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+GIT_SHA="$(git describe --always --dirty)"
+
+echo "Git hash: $GIT_SHA"
+
+DOCKER_BUILDKIT=1 docker build -t jitolabs/jito-transaction-relayer . --progress=plain
+
+# Creates a temporary container, copies binaries built inside container and removes the temporary container.
+docker rm temp || true
+docker container create --name temp jitolabs/jito-transaction-relayer
+mkdir -p "$SCRIPT_DIR"/docker-output
+# Outputs the binaries
+docker container cp temp:/app/jito-transaction-relayer "$SCRIPT_DIR"/docker-output
+docker container cp temp:/app/jito-packet-blaster "$SCRIPT_DIR"/docker-output
+docker rm temp

--- a/jito-protos/Cargo.toml
+++ b/jito-protos/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bytes = "1.1.0"
-prost = "0.10.1"
-prost-types = "0.10.1"
+bytes = "1.4.0"
+prost = "0.11.8"
+prost-types = "0.11.8"
 solana-perf = "=1.14.13"
 solana-sdk = "=1.14.13"
-tonic = "0.7.2"
+tonic = "0.8.3"
 
 [build-dependencies]
-tonic-build = "0.7.2"
+tonic-build = "0.8.4"

--- a/jito-protos/src/convert.rs
+++ b/jito-protos/src/convert.rs
@@ -7,7 +7,7 @@ use crate::packet::{Meta as ProtoMeta, Packet as ProtoPacket, PacketFlags as Pro
 
 pub fn packet_to_proto_packet(p: &Packet) -> Option<ProtoPacket> {
     Some(ProtoPacket {
-        data: p.data(0..p.meta.size)?.to_vec(),
+        data: p.data(..)?.to_vec(),
         meta: Some(ProtoMeta {
             size: p.meta.size as u64,
             addr: p.meta.addr.to_string(),

--- a/packet_blaster/Cargo.toml
+++ b/packet_blaster/Cargo.toml
@@ -5,10 +5,17 @@ edition = "2021"
 
 [dependencies]
 bincode = "1.3.3"
-clap = { version = "3.1.12", features = ["derive", "env"] }
-env_logger = "0.9.0"
+clap = { version = "4", features = ["derive", "env"] }
+env_logger = "0.9"
+futures-util = "0.3"
 log = "0.4.17"
-solana-client = "1.10.24"
-solana-perf = "1.10.24"
-solana-sdk = "1.10.24"
-tokio = { version = "1.14.1", features = ["rt-multi-thread"] }
+once_cell = "1"
+quinn = "0.9"
+rustls = { version = "0.20", features = ["dangerous_configuration"] }
+solana-client = "=1.14.13"
+solana-perf = "=1.14.13"
+solana-net-utils = "=1.14.13"
+solana-sdk = "=1.14.13"
+solana-streamer = "=1.14.13"
+thiserror = "1.0"
+tokio = { version = "~1.14.1", features = ["rt-multi-thread"] }

--- a/packet_blaster/Cargo.toml
+++ b/packet_blaster/Cargo.toml
@@ -8,6 +8,7 @@ bincode = "1.3.3"
 clap = { version = "4", features = ["derive", "env"] }
 env_logger = "0.9"
 futures-util = "0.3"
+itertools = "0.10"
 log = "0.4.17"
 once_cell = "1"
 quinn = "0.9"

--- a/packet_blaster/src/main.rs
+++ b/packet_blaster/src/main.rs
@@ -1,107 +1,238 @@
 use std::{
-    fmt::Write,
-    io,
-    net::{SocketAddr, UdpSocket},
-    str::FromStr,
+    fs, io,
+    io::ErrorKind,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    ops::Sub,
+    path::PathBuf,
     sync::Arc,
+    thread,
     thread::Builder,
     time::{Duration, Instant},
 };
 
 use bincode::serialize;
 use clap::Parser;
+use itertools::Itertools;
 use log::*;
+use once_cell::sync::Lazy;
 use solana_client::{
-    connection_cache::ConnectionCacheStats, nonblocking::quic_client::QuicLazyInitializedEndpoint,
-    quic_client::QuicTpuConnection, rpc_client::RpcClient, tpu_connection::TpuConnection,
+    client_error::{ClientError, ClientErrorKind},
+    connection_cache::ConnectionCacheStats,
+    nonblocking::quic_client::QuicLazyInitializedEndpoint,
+    quic_client::QuicTpuConnection,
+    rpc_client::RpcClient,
+    tpu_connection::TpuConnection,
 };
 use solana_sdk::{
+    native_token::LAMPORTS_PER_SOL,
+    pubkey::Pubkey,
     signature::{Keypair, Signature, Signer},
     system_transaction::transfer,
 };
 
-#[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[derive(Parser, Clone, Debug)]
+#[command(author, version, about, long_about = None)]
 struct Args {
-    /// RPC address
-    #[clap(long, env, value_parser, default_value = "http://127.0.0.1:8899")]
+    /// RPC address to get recent blockhash
+    #[arg(long, env, default_value = "http://127.0.0.1:8899")]
     rpc_addr: String,
 
-    /// Number of keypairs
-    #[clap(long, env, value_parser, default_value_t = 10)]
-    num_keypairs: u64,
+    /// Path to signer+payer keypairs
+    #[arg(long, env)]
+    keypair_path: PathBuf,
 
     /// Socket address for relayer TPU
-    #[clap(long, env, value_parser, default_value = "127.0.0.1:11222")]
-    tpu_addr: String,
+    #[arg(long, env, default_value = "127.0.0.1:8009")]
+    tpu_addr: SocketAddr,
 
-    /// Flag to use quic for relayer TPU
-    #[clap(long, env, value_parser, default_value_t = false)]
-    use_quic: bool,
+    /// Offset starting ip and port to allow multiple instances of packet blaster to run on the same machine
+    #[arg(long, env, default_value_t = 0)]
+    ip_port_offset: u16,
+
+    /// Interval between sending packets on a given thread
+    #[arg(long, env)]
+    loop_sleep_micros: Option<u64>,
+
+    /// Method of connecting to Solana TPU
+    #[command(subcommand)]
+    connection_mode: Mode,
 }
+
+#[derive(clap::Subcommand, Debug, Clone)]
+enum Mode {
+    /// Solana Quic
+    Quic,
+
+    /// Quinn client
+    Quinn {
+        /// Creates as many 127.x.x.x addresses as pubkeys provided.
+        /// Only works from localhost relative to relayer.
+        #[arg(long, env)]
+        spam_from_localhost: bool,
+    },
+
+    /// Quinn client sending packets slowly
+    SlowLoris {
+        /// Creates as many 127.x.x.x addresses as pubkeys provided.
+        /// Only works from localhost relative to relayer.
+        #[arg(long, env)]
+        spam_from_localhost: bool,
+
+        /// Number of bytes to write each time. Less than 4 bytes tends to drop connections after a few mins.
+        #[arg(long, env, default_value_t = 4)]
+        chunk_size: usize,
+
+        /// Sleep delay between bytes to execute slow loris attack
+        /// Must send in less than 100ms: https://github.com/solana-labs/solana/blob/cd6ba30cb0f990079a3d22e62d4f7f315ede4ce4/streamer/src/nonblocking/quic.rs#L42
+        #[arg(long, env, default_value_t = 50)]
+        sleep_interval_ms: u64,
+
+        /// Number of connections per IP.
+        /// Default relayer limit is 8.
+        // FIXME not hooked up
+        #[arg(long, env, default_value_t = 8)]
+        num_connections: u64,
+
+        /// Number of streams per connection.
+        #[arg(long, env, default_value_t = solana_sdk::quic::QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS as u64)]
+        num_streams_per_conn: u64,
+    },
+}
+
+fn read_keypairs(path: PathBuf) -> io::Result<Vec<Keypair>> {
+    if path.is_dir() {
+        let result = fs::read_dir(path)?
+            .filter_map(|entry| solana_sdk::signature::read_keypair_file(entry.ok()?.path()).ok())
+            .collect::<Vec<_>>();
+        Ok(result)
+    } else {
+        Ok(vec![Keypair::from_bytes(&fs::read(path)?).map_err(
+            |e| io::Error::new(ErrorKind::NotFound, e.to_string()),
+        )?])
+    }
+}
+
+const TXN_BATCH_SIZE: u64 = 10;
+
+/// Generates sequential localhost sockets on different IPs
+pub fn local_socket_addr(
+    ip_port_offset: u16,
+    thread_id: usize,
+    spam_from_localhost: bool,
+) -> SocketAddr {
+    let offset = ip_port_offset as u32 + thread_id as u32;
+    let ip: [u8; 4] = offset.to_be_bytes();
+    let port = 1024 + offset as u16;
+    match spam_from_localhost {
+        true => SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, ip[1], ip[2], ip[3])), port),
+        false => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port), /* for sending from remote machine */
+    }
+}
+
+static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+});
 
 fn main() {
     env_logger::init();
 
     let args: Args = Args::parse();
+    dbg!(&args);
 
-    let keypairs: Vec<_> = (0..args.num_keypairs)
-        .map(|_| Arc::new(Keypair::new()))
-        .collect();
+    let keypairs = read_keypairs(args.keypair_path.clone()).expect("Failed to read keypairs");
+    let pubkeys = keypairs
+        .iter()
+        .map(|kp| kp.pubkey())
+        .collect::<Vec<Pubkey>>();
 
-    let pubkeys: Vec<_> = keypairs.iter().map(|kp| kp.pubkey()).collect();
-    let mut pubkeys_str = pubkeys.iter().fold(String::new(), |mut s, pubkey| {
-        let _ = write!(s, "{pubkey},");
-        s
-    });
-    // remove last comma
-    let _ = pubkeys_str.pop();
-    info!("using keypairs: {:?}", pubkeys_str);
+    let starting_port = 1024 + args.ip_port_offset;
+    info!(
+        "Packet blaster will send on ports {}..={} with {} pubkeys: {pubkeys:?}",
+        starting_port,
+        starting_port + pubkeys.len() as u16,
+        pubkeys.len()
+    );
 
-    let client = Arc::new(RpcClient::new(&args.rpc_addr));
-    assert!(request_and_confirm_airdrop(&client, &pubkeys));
-
-    let tpu_addr = SocketAddr::from_str(&args.tpu_addr).unwrap();
     let threads: Vec<_> = keypairs
         .into_iter()
-        .map(|keypair| {
+        .enumerate()
+        .map(|(thread_id, keypair)| {
             let client = Arc::new(RpcClient::new(&args.rpc_addr));
+            let args = args.clone();
             Builder::new()
+                .name(format!("packet_blaster-thread_{thread_id}"))
                 .spawn(move || {
-                    let tpu_sender = TpuSender::new(tpu_addr, &args.use_quic);
+                    let tpu_sender = match RUNTIME.block_on(TpuSender::new(&args, thread_id)) {
+                        Ok(x) => x,
+                        Err(e) => panic!("Failed to connect, err: {e}"),
+                    };
+                    let metrics_interval = Duration::from_secs(5);
                     let mut last_blockhash_refresh = Instant::now();
                     let mut latest_blockhash = client.get_latest_blockhash().unwrap();
-                    let mut last_count = 0;
-                    info!("sending packets...");
-                    let mut count: u64 = 0;
+                    let mut curr_success_count = 0u64;
+                    let mut curr_fail_count = 0u64;
+                    let mut cumm_success_count = 0u64;
+                    let mut cumm_fail_count = 0u64;
                     loop {
-                        if last_blockhash_refresh.elapsed() > Duration::from_secs(5) {
-                            let packets_per_second = (count - last_count) as f64
-                                / last_blockhash_refresh.elapsed().as_secs_f64();
+                        let now = Instant::now();
+                        let elapsed = now.sub(last_blockhash_refresh);
+                        if elapsed > metrics_interval {
+                            cumm_success_count += curr_success_count;
+                            cumm_fail_count += curr_fail_count;
+                            let curr_txn_count = curr_success_count + curr_fail_count;
+                            let total_txn_count = cumm_success_count + cumm_fail_count;
                             info!(
-                                "packets sent/s: {:.2} ({} total)",
-                                packets_per_second, count
+                                "thread_{thread_id} msgs/sec: {:.0}, \
+                                success: {curr_success_count}, \
+                                fail: {curr_fail_count}, \
+                                total txn: {total_txn_count}, \
+                                overall success %: {:.1}",
+                                (curr_txn_count) as f64 / elapsed.as_secs_f64(),
+                                (cumm_success_count as f64 / total_txn_count as f64) * 100.0
                             );
+                            last_blockhash_refresh = now;
 
-                            last_blockhash_refresh = Instant::now();
+                            curr_success_count = 0;
+                            curr_fail_count = 0;
                             latest_blockhash = client.get_latest_blockhash().unwrap();
-                            last_count = count;
                         }
 
-                        let serialized_txs: Vec<Vec<u8>> = (0..10)
-                            .map(|_| {
-                                count += 1;
-                                serialize(&transfer(
+                        let count = cumm_success_count
+                            + cumm_fail_count
+                            + curr_success_count
+                            + curr_fail_count;
+                        let serialized_txns: Vec<Vec<u8>> = (0..TXN_BATCH_SIZE)
+                            .filter_map(|i| {
+                                let lamports = count + i;
+                                let txn = transfer(
                                     &keypair,
                                     &keypair.pubkey(),
-                                    count,
+                                    lamports,
                                     latest_blockhash,
-                                ))
-                                .unwrap()
+                                );
+                                // debug!(
+                                //     "pubkey: {}, lamports: {}, signature: {:?}",
+                                //     &keypair.pubkey(),
+                                //     lamports,
+                                //     &txn.signatures
+                                // );
+                                serialize(&txn).ok()
                             })
                             .collect();
+                        let (_successes, fails): (Vec<()>, Vec<PacketBlasterError>) = RUNTIME
+                            .block_on(tpu_sender.send(serialized_txns))
+                            .into_iter()
+                            .partition_result();
+                        curr_success_count += _successes.len() as u64;
 
-                        tpu_sender.send(serialized_txs);
+                        curr_fail_count += fails.len() as u64;
+
+                        if let Some(dur) = args.loop_sleep_micros {
+                            thread::sleep(Duration::from_micros(dur))
+                        }
                     }
                 })
                 .unwrap()
@@ -113,66 +244,229 @@ fn main() {
     }
 }
 
-fn request_and_confirm_airdrop(client: &RpcClient, pubkeys: &[solana_sdk::pubkey::Pubkey]) -> bool {
-    let sigs: Vec<_> = pubkeys
-        .iter()
-        .map(|pubkey| client.request_airdrop(pubkey, 100_000_000_000))
-        .collect();
-
-    if sigs.iter().any(|s| s.is_err()) {
-        return false;
-    }
-    let sigs: Vec<Signature> = sigs.into_iter().map(|s| s.unwrap()).collect();
-
-    let now = Instant::now();
-    while now.elapsed() < Duration::from_secs(20) {
-        let r = client.get_signature_statuses(&sigs).expect("got statuses");
-        if r.value.iter().all(|s| s.is_some()) {
-            return true;
-        }
-    }
-    false
-}
-
 enum TpuSender {
-    UdpSender {
-        address: SocketAddr,
-        sock: UdpSocket,
+    Quinn {
+        connection: quinn::Connection,
     },
-    QuicSender {
+    SlowLoris {
+        connection: Arc<quinn::Connection>,
+        chunk_size: usize,
+        num_streams_per_conn: u64,
+        sleep_interval: Duration,
+    },
+    Quic {
         client: QuicTpuConnection,
     },
 }
 
+// taken from https://github.com/solana-labs/solana/blob/527e2d4f59c6429a4a959d279738c872b97e56b5/client/src/nonblocking/quic_client.rs#L42
+struct SkipServerVerification;
+
+impl SkipServerVerification {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self)
+    }
+}
+
+impl rustls::client::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &rustls::ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: std::time::SystemTime,
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::ServerCertVerified::assertion())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PacketBlasterError {
+    #[error("connect error: {0}")]
+    ConnectError(#[from] quinn::ConnectError),
+    #[error("connection error: {0}")]
+    ConnectionError(#[from] quinn::ConnectionError),
+    #[error("write error: {0}")]
+    WriteError(#[from] quinn::WriteError),
+    #[error("transport error: {0}")]
+    TransportError(#[from] solana_sdk::transport::TransportError),
+}
+
 impl TpuSender {
-    fn new(addr: SocketAddr, use_quic: &bool) -> TpuSender {
-        if *use_quic {
-            TpuSender::QuicSender {
+    // source taken from https://github.com/solana-labs/solana/blob/527e2d4f59c6429a4a959d279738c872b97e56b5/client/src/nonblocking/quic_client.rs#L93
+    // original code doesn't allow specifying source socket
+    fn create_endpoint(send_addr: SocketAddr) -> quinn::Endpoint {
+        let (certs, priv_key) =
+            solana_streamer::tls_certificates::new_self_signed_tls_certificate_chain(
+                &Keypair::new(),
+                send_addr.ip(),
+            )
+            .expect("Failed to create QUIC client certificate");
+        let mut crypto = rustls::ClientConfig::builder()
+            .with_safe_defaults()
+            .with_custom_certificate_verifier(SkipServerVerification::new())
+            .with_single_cert(certs, priv_key)
+            .expect("Failed to set QUIC client certificates");
+        crypto.enable_early_data = true;
+        crypto.alpn_protocols =
+            vec![solana_streamer::nonblocking::quic::ALPN_TPU_PROTOCOL_ID.to_vec()];
+
+        let mut endpoint = quinn::Endpoint::client(send_addr).unwrap();
+        let mut config = quinn::ClientConfig::new(Arc::new(crypto));
+
+        let mut transport_config = quinn::TransportConfig::default();
+        let timeout = quinn::IdleTimeout::from(quinn::VarInt::from_u32(
+            solana_sdk::quic::QUIC_MAX_TIMEOUT_MS * 100, /* Hack for when relayer is backed up and not accepting connections */
+        ));
+        transport_config.max_idle_timeout(Some(timeout));
+        transport_config.keep_alive_interval(Some(Duration::from_millis(
+            solana_sdk::quic::QUIC_KEEP_ALIVE_MS,
+        )));
+        config.transport_config(Arc::new(transport_config));
+
+        endpoint.set_default_client_config(config);
+        endpoint
+    }
+
+    async fn new(args: &Args, thread_id: usize) -> Result<TpuSender, PacketBlasterError> {
+        match args.connection_mode {
+            Mode::Quinn {
+                spam_from_localhost,
+            } => {
+                let connection = Self::setup_quinn_sender(
+                    args.tpu_addr,
+                    args.ip_port_offset,
+                    thread_id,
+                    spam_from_localhost,
+                )
+                .await;
+                Ok(TpuSender::Quinn { connection })
+            }
+            Mode::SlowLoris {
+                spam_from_localhost,
+                chunk_size,
+                sleep_interval_ms,
+                num_streams_per_conn,
+                num_connections: _num_connections,
+            } => {
+                let connection = Self::setup_quinn_sender(
+                    args.tpu_addr,
+                    args.ip_port_offset,
+                    thread_id,
+                    spam_from_localhost,
+                )
+                .await;
+                Ok(TpuSender::SlowLoris {
+                    connection: Arc::new(connection),
+                    chunk_size,
+                    num_streams_per_conn,
+                    sleep_interval: Duration::from_millis(sleep_interval_ms),
+                })
+            }
+            Mode::Quic => Ok(TpuSender::Quic {
                 client: QuicTpuConnection::new(
                     Arc::new(QuicLazyInitializedEndpoint::default()),
-                    addr,
+                    args.tpu_addr,
                     Arc::new(ConnectionCacheStats::default()),
                 ),
-            }
-        } else {
-            TpuSender::UdpSender {
-                address: addr,
-                sock: UdpSocket::bind("0.0.0.0:0").unwrap(),
-            }
+            }),
         }
     }
 
-    fn send(&self, serialized_txs: Vec<Vec<u8>>) {
+    async fn setup_quinn_sender(
+        dest_addr: SocketAddr,
+        ip_port_offset: u16,
+        thread_id: usize,
+        spam_from_localhost: bool,
+    ) -> quinn::Connection {
+        let send_socket_addr = local_socket_addr(ip_port_offset, thread_id, spam_from_localhost);
+        let endpoint = Self::create_endpoint(send_socket_addr);
+        // Connect to the server passing in the server name which is supposed to be in the server certificate.
+        let connection = endpoint
+            .connect(dest_addr, "connect")
+            .unwrap()
+            .await
+            .unwrap_or_else(|_| {
+                panic!("Failed to bind thread_{thread_id} to {send_socket_addr:?}")
+            });
+        info!("Sending thread_{thread_id} packets on {send_socket_addr:?}");
+
+        connection
+    }
+
+    async fn send(&self, serialized_txns: Vec<Vec<u8>>) -> Vec<Result<(), PacketBlasterError>> {
         match self {
-            TpuSender::UdpSender { address, sock } => {
-                let _: Vec<io::Result<usize>> = serialized_txs
-                    .iter()
-                    .map(|tx| sock.send_to(tx, address))
-                    .collect();
+            TpuSender::Quinn { connection } => {
+                let futures = serialized_txns.into_iter().map(|buf| async move {
+                    let mut send_stream = connection.open_uni().await?;
+                    send_stream.write_all(&buf).await?;
+                    send_stream.finish().await?;
+                    Ok::<(), PacketBlasterError>(())
+                });
+
+                let results: Vec<Result<(), PacketBlasterError>> =
+                    futures_util::future::join_all(futures).await;
+
+                results
             }
-            TpuSender::QuicSender { client } => client
-                .send_wire_transaction_batch_async(serialized_txs)
-                .expect("quic send panic"),
+            TpuSender::SlowLoris {
+                connection,
+                chunk_size,
+                sleep_interval,
+                num_streams_per_conn,
+            } => {
+                let futures = serialized_txns
+                    .into_iter()
+                    .cartesian_product(0..*num_streams_per_conn)
+                    .map(|(txn, _stream_id)| async move {
+                        let mut send_stream = connection
+                            .open_uni()
+                            .await
+                            .map_err(PacketBlasterError::ConnectionError)?;
+                        // less than 4 bytes fails after a few mins
+                        for chunk in txn.chunks(*chunk_size) {
+                            // info!("sending byte[{i}] for stream_{stream_id}");
+                            send_stream.write_all(chunk).await?;
+                            tokio::time::sleep(*sleep_interval).await;
+                        }
+                        send_stream.finish().await?;
+
+                        Ok::<(), PacketBlasterError>(())
+                    });
+
+                let results: Vec<Result<(), PacketBlasterError>> =
+                    futures_util::future::join_all(futures).await;
+                results
+            }
+            TpuSender::Quic { client } => {
+                vec![client
+                    .send_wire_transaction_batch_async(serialized_txns)
+                    .map_err(PacketBlasterError::TransportError)]
+            }
         }
     }
+}
+
+#[allow(unused)]
+fn request_and_confirm_airdrop(
+    client: &RpcClient,
+    pubkeys: &[Pubkey],
+) -> solana_client::client_error::Result<()> {
+    let sigs = pubkeys
+        .iter()
+        .map(|pubkey| client.request_airdrop(pubkey, 100 * LAMPORTS_PER_SOL))
+        .collect::<solana_client::client_error::Result<Vec<Signature>>>()?;
+
+    let now = Instant::now();
+    while now.elapsed() < Duration::from_secs(20) {
+        let r = client.get_signature_statuses(&sigs)?;
+        if r.value.iter().all(|s| s.is_some()) {
+            return Err(ClientError::from(ClientErrorKind::Custom(
+                "signature error".to_string(),
+            )));
+        }
+    }
+    Ok(())
 }

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-chrono = "0.4.22"
-crossbeam-channel = "0.5.4"
+chrono = "0.4.24"
+crossbeam-channel = "0.5.7"
 ed25519-dalek = "1.0.1"
 histogram = "0.6.9"
 jito-protos = { path = "../jito-protos" }
@@ -17,16 +17,16 @@ jito-rpc = { path = "../rpc" }
 jwt = { version = "0.16.0", features = ["openssl"] }
 keyed_priority_queue = "0.4.1"
 log = "0.4.17"
-openssl = "0.10.41"
-prost-types = "0.10.1"
+openssl = "0.10.49"
+prost-types = "0.11.8"
 rand = "0.8.5"
-serde = "1.0.143"
-sha2 = "0.10.2"
+serde = "1.0.159"
+sha2 = "0.10.6"
 solana-client = "=1.14.13"
 solana-metrics = "=1.14.13"
 solana-perf = "=1.14.13"
 solana-sdk = "=1.14.13"
-thiserror = "1.0.31"
-tokio = { version = "1.14.1" }
-tokio-stream = "0.1.9"
-tonic = "0.7.2"
+thiserror = "1.0.40"
+tokio = { version = "~1.14.1" }
+tokio-stream = "0.1.12"
+tonic = "0.8.3"

--- a/relayer/src/auth_interceptor.rs
+++ b/relayer/src/auth_interceptor.rs
@@ -33,7 +33,8 @@ impl From<&DeSerClaims> for Claims {
         Self {
             client_ip: IpAddr::from_str(&de_ser_claims.client_ip).unwrap(),
             client_pubkey: Pubkey::from_str(&de_ser_claims.client_pubkey).unwrap(),
-            expires_at_utc: NaiveDateTime::from_timestamp(de_ser_claims.expires_at_unix_ts, 0),
+            expires_at_utc: NaiveDateTime::from_timestamp_opt(de_ser_claims.expires_at_unix_ts, 0)
+                .unwrap(),
         }
     }
 }

--- a/relayer/src/health_manager.rs
+++ b/relayer/src/health_manager.rs
@@ -65,7 +65,8 @@ impl HealthManager {
                             recv(channel_len_tick) -> _ => {
                                 datapoint_info!(
                                     "health_manager-channel_stats",
-                                    ("slot_sender-len", slot_sender_max_len, i64),
+                                    ("slot_sender_len", slot_sender_max_len, i64),
+                                    ("slot_sender_capacity", slot_sender.capacity().unwrap(), i64),
                                 );
                                 slot_sender_max_len = 0;
                             }

--- a/relayer/src/health_manager.rs
+++ b/relayer/src/health_manager.rs
@@ -9,14 +9,13 @@ use std::{
 };
 
 use crossbeam_channel::{select, tick, Receiver, Sender};
-use log::error;
 use solana_metrics::datapoint_info;
 use solana_sdk::clock::Slot;
 
 #[derive(PartialEq, Eq, Copy, Clone)]
 pub enum HealthState {
-    Unhealthy,
-    Healthy,
+    Unhealthy = 0,
+    Healthy = 1,
 }
 
 pub struct HealthManager {
@@ -30,71 +29,52 @@ impl HealthManager {
     pub fn new(
         slot_receiver: Receiver<Slot>,
         slot_sender: Sender<Slot>,
-        missing_slot_unhealthy_duration: Duration,
-        exit: &Arc<AtomicBool>,
-        cluster: String,
-        region: String,
+        missing_slot_unhealthy_threshold: Duration,
+        exit: Arc<AtomicBool>,
     ) -> HealthManager {
         let health_state = Arc::new(RwLock::new(HealthState::Unhealthy));
         HealthManager {
             state: health_state.clone(),
-            manager_thread: Self::start_manager_thread(
-                slot_receiver,
-                slot_sender,
-                missing_slot_unhealthy_duration,
-                exit,
-                health_state,
-                cluster,
-                region,
-            ),
-        }
-    }
+            manager_thread: Builder::new()
+                .name("health_manager".to_string())
+                .spawn(move || {
+                    let mut last_update = Instant::now();
+                    let mut slot_sender_max_len = 0usize;
+                    let channel_len_tick = tick(Duration::from_secs(5));
+                    let check_and_metrics_tick = tick(missing_slot_unhealthy_threshold / 2);
 
-    pub fn start_manager_thread(
-        slot_receiver: Receiver<Slot>,
-        slot_sender: Sender<Slot>,
-        missing_slot_unhealthy_duration: Duration,
-        exit: &Arc<AtomicBool>,
-        health_state: Arc<RwLock<HealthState>>,
-        cluster: String,
-        region: String,
-    ) -> JoinHandle<()> {
-        let exit = exit.clone();
-        Builder::new()
-            .name("health-manager".to_string())
-            .spawn(move || {
-                let mut last_update = Instant::now();
-                let check_and_metrics_tick = tick(missing_slot_unhealthy_duration / 2);
-
-                while !exit.load(Ordering::Relaxed) {
-                    select! {
-                        recv(check_and_metrics_tick) -> _ => {
-                            let is_err = last_update.elapsed() > missing_slot_unhealthy_duration;
-                            let new_health_state = if is_err { HealthState::Unhealthy } else { HealthState::Healthy };
-                            *health_state.write().unwrap() = new_health_state;
-                            datapoint_info!(
-                                "relayer-health-state",
-                                "cluster" => cluster,
-                                "region" => region,
-                                ("health_state", new_health_state as i64, i64)
-                            );
-                        }
-                        recv(slot_receiver) -> maybe_slot => {
-                            if maybe_slot.is_err() {
-                                error!("error receiving slot, exiting");
-                                break;
+                    while !exit.load(Ordering::Relaxed) {
+                        select! {
+                            recv(check_and_metrics_tick) -> _ => {
+                                let new_health_state =
+                                    match last_update.elapsed() <= missing_slot_unhealthy_threshold {
+                                        true => HealthState::Healthy,
+                                        false => HealthState::Unhealthy,
+                                    };
+                                *health_state.write().unwrap() = new_health_state;
+                                datapoint_info!(
+                                    "relayer-health-state",
+                                    ("health_state", new_health_state, i64)
+                                );
                             }
-                            let slot = maybe_slot.unwrap();
-                            if slot_sender.send(slot).is_err() {
-                                error!("error forwarding slot, exiting");
-                                break;
+                            recv(slot_receiver) -> maybe_slot => {
+                                let slot = maybe_slot.expect("error receiving slot, exiting");
+                                slot_sender.send(slot).expect("error forwarding slot, exiting");
+                                last_update = Instant::now();
                             }
-                            last_update = Instant::now();
+                            recv(channel_len_tick) -> _ => {
+                                datapoint_info!(
+                                    "health_manager-channel_stats",
+                                    ("slot_sender-len", slot_sender_max_len, i64),
+                                );
+                                slot_sender_max_len = 0;
+                            }
                         }
+                        slot_sender_max_len = std::cmp::max(slot_sender_max_len, slot_sender.len());
                     }
-                }
-            })
-            .unwrap()
+                })
+                .unwrap(),
+        }
     }
 
     /// Return a handle to the health manager state

--- a/relayer/src/schedule_cache.rs
+++ b/relayer/src/schedule_cache.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Mutex, RwLock,
+        Arc, RwLock,
     },
     thread,
     thread::{sleep, Builder, JoinHandle},
@@ -60,19 +60,11 @@ impl LeaderScheduleUpdatingHandle {
 
 impl LeaderScheduleCacheUpdater {
     pub fn new(
-        load_balancer: &Arc<Mutex<LoadBalancer>>,
+        load_balancer: &Arc<LoadBalancer>,
         exit: &Arc<AtomicBool>,
-        cluster: String,
-        region: String,
     ) -> LeaderScheduleCacheUpdater {
         let schedules = Arc::new(RwLock::new(HashMap::new()));
-        let refresh_thread = Self::refresh_thread(
-            schedules.clone(),
-            load_balancer.clone(),
-            exit,
-            cluster,
-            region,
-        );
+        let refresh_thread = Self::refresh_thread(schedules.clone(), load_balancer.clone(), exit);
         LeaderScheduleCacheUpdater {
             schedules,
             refresh_thread,
@@ -90,34 +82,26 @@ impl LeaderScheduleCacheUpdater {
 
     fn refresh_thread(
         schedule: Arc<RwLock<HashMap<Slot, Pubkey>>>,
-        load_balancer: Arc<Mutex<LoadBalancer>>,
+        load_balancer: Arc<LoadBalancer>,
         exit: &Arc<AtomicBool>,
-        cluster: String,
-        region: String,
     ) -> JoinHandle<()> {
         let exit = exit.clone();
         Builder::new()
-            .name("leader-schedule-refresh".into())
+            .name("leader-schedule-refresh".to_string())
             .spawn(move || {
                 while !exit.load(Ordering::Relaxed) {
                     let mut update_ok_count = 0;
                     let mut update_fail_count = 0;
 
                     match Self::update_leader_cache(&load_balancer, &schedule) {
-                        true => {
-                            update_ok_count += 1;
-                        }
-                        false => {
-                            update_fail_count += 1;
-                        }
+                        true => update_ok_count += 1,
+                        false => update_fail_count += 1,
                     }
 
                     let slots_in_schedule = schedule.read().unwrap().len();
 
                     datapoint_info!(
                         "schedule-cache-update",
-                        "cluster" => cluster,
-                        "region" => region,
                         ("update_ok_count", update_ok_count, i64),
                         ("update_fail_count", update_fail_count, i64),
                         ("slots_in_schedule", slots_in_schedule, i64),
@@ -130,10 +114,10 @@ impl LeaderScheduleCacheUpdater {
     }
 
     pub fn update_leader_cache(
-        load_balancer: &Arc<Mutex<LoadBalancer>>,
+        load_balancer: &Arc<LoadBalancer>,
         schedule: &Arc<RwLock<HashMap<Slot, Pubkey>>>,
     ) -> bool {
-        let rpc_client = load_balancer.lock().unwrap().rpc_client();
+        let rpc_client = load_balancer.rpc_client();
 
         if let Ok(epoch_info) = rpc_client.get_epoch_info() {
             if let Ok(Some(leader_schedule)) = rpc_client.get_leader_schedule(None) {

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-crossbeam-channel = "0.5.4"
+crossbeam-channel = "0.5.7"
+dashmap = "5"
 log = "0.4.17"
 solana-client = "=1.14.13"
 solana-metrics = "=1.14.13"

--- a/rpc/src/load_balancer.rs
+++ b/rpc/src/load_balancer.rs
@@ -54,7 +54,7 @@ impl LoadBalancer {
             (ws.clone(), rpc_client)
         }));
 
-        // sender tracked as health_manager-channel_stats.slot_sender-len
+        // sender tracked as health_manager-channel_stats.slot_sender_len
         let (slot_sender, slot_receiver) = crossbeam_channel::bounded(Self::SLOT_QUEUE_CAPACITY);
         let subscription_threads =
             Self::start_subscription_threads(servers, server_to_slot.clone(), slot_sender, exit);

--- a/transaction-relayer/Cargo.toml
+++ b/transaction-relayer/Cargo.toml
@@ -9,21 +9,22 @@ publish = false
 
 [dependencies]
 bincode = "1.3.3"
-clap = { version = "3.1.12", features = ["derive", "env"] }
-crossbeam-channel = "0.5.5"
+clap = { version = "4", features = ["derive", "env"] }
+crossbeam-channel = "0.5.7"
 dashmap = "5.4.0"
-env_logger = "0.9.0"
-itertools = "0.10.3"
+env_logger = "0.9"
+hostname = "0.3"
+itertools = "0.10.5"
 jito-block-engine = { path = "../block_engine", version = "0.1.0" }
 jito-core = { path = "../core" }
 jito-protos = { path = "../jito-protos" }
 jito-relayer = { path = "../relayer" }
 jito-rpc = { path = "../rpc" }
 jwt = { version = "0.16.0", features = ["openssl"] }
-log = "0.4.14"
-openssl = "0.10.41"
-prost-types = "0.10.1"
-reqwest = "0.11.13"
+log = "0.4.17"
+openssl = "0.10.49"
+prost-types = "0.11.8"
+reqwest = "0.11.16"
 solana-address-lookup-table-program = "=1.14.13"
 solana-client = "=1.14.13"
 solana-core = "=1.14.13"
@@ -32,6 +33,6 @@ solana-net-utils = "=1.14.13"
 solana-perf = "=1.14.13"
 solana-program = "=1.14.13"
 solana-sdk = "=1.14.13"
-tokio = { version = "1.14.1", features = ["rt-multi-thread"] }
-tokio-stream = "0.1.8"
-tonic = "0.7.2"
+tokio = { version = "~1.14.1", features = ["rt-multi-thread"] }
+tokio-stream = "0.1.12"
+tonic = "0.8.3"

--- a/transaction-relayer/src/forwarder.rs
+++ b/transaction-relayer/src/forwarder.rs
@@ -10,91 +10,47 @@ use std::{
 
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use jito_block_engine::block_engine::BlockEnginePackets;
-use jito_relayer::relayer::RouterPacketBatches;
-use log::error;
+use jito_relayer::relayer::RelayerPacketBatches;
 use solana_core::banking_stage::BankingPacketBatch;
 use solana_metrics::datapoint_info;
 use solana_perf::packet::PacketBatch;
 use tokio::sync::mpsc::error::TrySendError;
 
-#[derive(Default)]
-struct ForwarderMetrics {
-    pub num_batches_received: u64,
-    pub num_packets_received: u64,
-    pub num_filtered_packets: u64,
+pub const BLOCK_ENGINE_FORWARDER_QUEUE_CAPACITY: usize = 5_000;
 
-    pub num_be_packets_forwarded: u64,
-    pub num_be_packets_dropped: u64,
-    pub num_be_times_full: u64,
-
-    pub num_relayer_packets_forwarded: u64,
-}
-
-impl ForwarderMetrics {
-    pub fn report(&self, id: u64, delay: u32, cluster: &str, region: &str) {
-        datapoint_info!(
-            "forward_and_delay",
-            "cluster" => cluster,
-            "region" => region,
-            ("id", id, i64),
-            ("delay", delay, i64),
-            ("num_batches_received", self.num_batches_received, i64),
-            ("num_packets_received", self.num_packets_received, i64),
-            ("num_filtered_packets", self.num_filtered_packets, i64),
-            // Relayer -> Block Engine Metrics
-            (
-                "num_be_packets_forwarded",
-                self.num_be_packets_forwarded,
-                i64
-            ),
-            ("num_be_packets_dropped", self.num_be_packets_dropped, i64),
-            ("num_be_times_full", self.num_be_times_full, i64),
-            // Relayer -> validator metrics
-            (
-                "num_relayer_packets_forwarded",
-                self.num_relayer_packets_forwarded,
-                i64
-            ),
-        );
-    }
-}
-
-/// Forwards packets to the Block Engine handler thread then delays transactions for packet_delay_ms
-/// before forwarding them to the validator.
+/// Forwards packets to the Block Engine handler thread.
+/// Delays transactions for packet_delay_ms before forwarding them to the validator.
 #[allow(clippy::too_many_arguments)]
 pub fn start_forward_and_delay_thread(
     packet_receiver: Receiver<BankingPacketBatch>,
-    delay_sender: Sender<RouterPacketBatches>,
+    delay_sender: Sender<RelayerPacketBatches>,
     packet_delay_ms: u32,
     block_engine_sender: tokio::sync::mpsc::Sender<BlockEnginePackets>,
     num_threads: u64,
     exit: &Arc<AtomicBool>,
-    cluster: String,
-    region: String,
 ) -> Vec<JoinHandle<()>> {
     const SLEEP_DURATION: Duration = Duration::from_millis(5);
     let packet_delay = Duration::from_millis(packet_delay_ms as u64);
 
     (0..num_threads)
-        .map(|i| {
+        .map(|thread_id| {
             let packet_receiver = packet_receiver.clone();
             let delay_sender = delay_sender.clone();
             let block_engine_sender = block_engine_sender.clone();
 
-            let cluster = cluster.clone();
-            let region = region.clone();
             let exit = exit.clone();
             Builder::new()
-                .name("jito-forward_packets_to_block_engine".into())
+                .name(format!("forwarder_thread_{thread_id}"))
                 .spawn(move || {
-                    let mut buffered_packet_batches = VecDeque::with_capacity(100_000);
-
+                    let metrics_interval = Duration::from_secs(1);
                     let mut forwarder_metrics = ForwarderMetrics::default();
                     let mut last_metrics_upload = Instant::now();
 
+                    let mut buffered_packet_batches = VecDeque::with_capacity(100_000);
+
                     while !exit.load(Ordering::Relaxed) {
-                        if last_metrics_upload.elapsed() >= Duration::from_secs(1) {
-                            forwarder_metrics.report(i, packet_delay_ms, &cluster, &region);
+                        if last_metrics_upload.elapsed() >= metrics_interval {
+                            forwarder_metrics.report(thread_id, packet_delay_ms);
 
                             forwarder_metrics = ForwarderMetrics::default();
                             last_metrics_upload = Instant::now();
@@ -130,7 +86,7 @@ pub fn start_forward_and_delay_thread(
                                 let num_batches_received = packet_batches.len() as u64;
 
                                 forwarder_metrics.num_packets_received += total_packets;
-                                forwarder_metrics.num_filtered_packets +=
+                                forwarder_metrics.num_packets_filtered +=
                                     total_packets - num_packets_received;
                                 forwarder_metrics.num_batches_received += num_batches_received;
 
@@ -146,48 +102,137 @@ pub fn start_forward_and_delay_thread(
                                             num_packets_received;
                                     }
                                     Err(TrySendError::Closed(_)) => {
-                                        error!(
+                                        panic!(
                                             "error sending packet batch to block engine handler"
                                         );
-                                        break;
                                     }
                                     Err(TrySendError::Full(_)) => {
                                         // block engine most likely not connected
                                         forwarder_metrics.num_be_packets_dropped +=
                                             num_packets_received;
-                                        forwarder_metrics.num_be_times_full += 1;
+                                        forwarder_metrics.num_be_sender_full += 1;
                                     }
                                 }
-                                buffered_packet_batches.push_back(RouterPacketBatches {
+                                buffered_packet_batches.push_back(RelayerPacketBatches {
                                     stamp: instant,
                                     batches: packet_batches,
                                 });
                             }
                             Err(RecvTimeoutError::Timeout) => {}
                             Err(RecvTimeoutError::Disconnected) => {
-                                break;
+                                panic!("packet receiver disconnected");
                             }
                         }
 
                         while let Some(packet_batches) = buffered_packet_batches.front() {
-                            if packet_batches.stamp.elapsed() >= packet_delay {
-                                let batch = buffered_packet_batches.pop_front().unwrap();
-
-                                let num_packets =
-                                    batch.batches.iter().map(|b| b.len() as u64).sum::<u64>();
-                                forwarder_metrics.num_relayer_packets_forwarded += num_packets;
-
-                                if let Err(e) = delay_sender.send(batch) {
-                                    error!("exiting forwarding delayed packets: {:?}", e);
-                                    return;
-                                }
-                            } else {
+                            if packet_batches.stamp.elapsed() < packet_delay {
                                 break;
                             }
+                            let batch = buffered_packet_batches.pop_front().unwrap();
+
+                            let num_packets =
+                                batch.batches.iter().map(|b| b.len() as u64).sum::<u64>();
+                            forwarder_metrics.num_relayer_packets_forwarded += num_packets;
+
+                            delay_sender
+                                .send(batch)
+                                .expect("exiting forwarding delayed packets");
                         }
+
+                        forwarder_metrics.update_queue_lengths(
+                            buffered_packet_batches.len(),
+                            buffered_packet_batches.capacity(),
+                            packet_receiver.len(),
+                            BLOCK_ENGINE_FORWARDER_QUEUE_CAPACITY - block_engine_sender.capacity(),
+                        );
                     }
                 })
                 .unwrap()
         })
         .collect()
+}
+
+#[derive(Default)]
+struct ForwarderMetrics {
+    pub num_batches_received: u64,
+    pub num_packets_received: u64,
+    pub num_packets_filtered: u64,
+
+    pub num_be_packets_forwarded: u64,
+    pub num_be_packets_dropped: u64,
+    pub num_be_sender_full: u64,
+
+    pub num_relayer_packets_forwarded: u64,
+
+    // high water mark on queue lengths
+    pub buffered_packet_batches_max_len: usize,
+    pub buffered_packet_batches_max_capacity: usize,
+    pub verified_receiver_max_len: usize,
+    pub block_engine_sender_max_len: usize,
+}
+
+impl ForwarderMetrics {
+    pub fn update_queue_lengths(
+        &mut self,
+        buffered_packet_batches_len: usize,
+        buffered_packet_batches_capacity: usize,
+        verified_receiver_len: usize,
+        block_engine_sender_len: usize,
+    ) {
+        self.buffered_packet_batches_max_len = std::cmp::max(
+            self.buffered_packet_batches_max_len,
+            buffered_packet_batches_len,
+        );
+        self.buffered_packet_batches_max_capacity = std::cmp::max(
+            self.buffered_packet_batches_max_capacity,
+            buffered_packet_batches_capacity,
+        );
+        self.verified_receiver_max_len =
+            std::cmp::max(self.verified_receiver_max_len, verified_receiver_len);
+
+        self.block_engine_sender_max_len =
+            std::cmp::max(self.block_engine_sender_max_len, block_engine_sender_len);
+    }
+
+    pub fn report(&self, thread_id: u64, delay: u32) {
+        datapoint_info!(
+            "forwarder_metrics",
+            ("thread_id", thread_id, i64),
+            ("delay", delay, i64),
+            ("num_batches_received", self.num_batches_received, i64),
+            ("num_packets_received", self.num_packets_received, i64),
+            ("num_packets_filtered", self.num_packets_filtered, i64),
+            // Relayer -> Block Engine Metrics
+            (
+                "num_be_packets_forwarded",
+                self.num_be_packets_forwarded,
+                i64
+            ),
+            ("num_be_packets_dropped", self.num_be_packets_dropped, i64),
+            ("num_be_sender_full", self.num_be_sender_full, i64),
+            // Relayer -> validator metrics
+            (
+                "num_relayer_packets_forwarded",
+                self.num_relayer_packets_forwarded,
+                i64
+            ),
+            // Channel stats
+            (
+                "buffered_packet_batches-len",
+                self.buffered_packet_batches_max_len,
+                i64
+            ),
+            (
+                "buffered_packet_batches-capacity",
+                self.buffered_packet_batches_max_capacity,
+                i64
+            ),
+            ("verified_receiver-len", self.verified_receiver_max_len, i64),
+            (
+                "block_engine_sender-len",
+                self.block_engine_sender_max_len,
+                i64
+            ),
+        );
+    }
 }

--- a/transaction-relayer/src/forwarder.rs
+++ b/transaction-relayer/src/forwarder.rs
@@ -20,7 +20,6 @@ pub const BLOCK_ENGINE_FORWARDER_QUEUE_CAPACITY: usize = 5_000;
 
 /// Forwards packets to the Block Engine handler thread.
 /// Delays transactions for packet_delay_ms before forwarding them to the validator.
-#[allow(clippy::too_many_arguments)]
 pub fn start_forward_and_delay_thread(
     packet_receiver: Receiver<BankingPacketBatch>,
     delay_sender: Sender<RelayerPacketBatches>,

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -1,12 +1,11 @@
 use std::{
     collections::HashSet,
-    fs::File,
-    io::Read,
-    net::{IpAddr, SocketAddr},
+    fs,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     str::FromStr,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
+        Arc,
     },
     thread,
     thread::JoinHandle,
@@ -14,7 +13,7 @@ use std::{
 };
 
 use clap::Parser;
-use crossbeam_channel::{tick, unbounded};
+use crossbeam_channel::tick;
 use dashmap::DashMap;
 use jito_block_engine::block_engine::BlockEngineRelayerHandler;
 use jito_core::{
@@ -51,125 +50,138 @@ use tonic::transport::Server;
 #[clap(author, version, about, long_about = None)]
 struct Args {
     /// IP address to bind to for transaction packets
-    #[clap(long, env, value_parser)]
+    #[arg(long, env, default_value_t = IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)))]
     tpu_bind_ip: IpAddr,
 
     /// Port to bind to advertise for TPU
     /// NOTE: There is no longer a socket created at this port since UDP transaction receiving is
     /// deprecated.
-    #[clap(long, env, value_parser, default_value_t = 11_222)]
+    #[arg(long, env, default_value_t = 11_222)]
     tpu_port: u16,
 
     /// Port to bind to for tpu fwd packets
     /// NOTE: There is no longer a socket created at this port since UDP transaction receiving is
     /// deprecated.
-    #[clap(long, env, value_parser, default_value_t = 11_223)]
+    #[arg(long, env, default_value_t = 11_223)]
     tpu_fwd_port: u16,
 
     /// Port to bind to for tpu packets. Needs to be tpu_port + 6
-    #[clap(long, env, value_parser, default_value_t = 11_228)]
+    #[arg(long, env, default_value_t = 11_228)]
     tpu_quic_port: u16,
 
     /// Port to bind to for tpu fwd packets. Needs to be tpu_fwd_port + 6
-    #[clap(long, env, value_parser, default_value_t = 11_229)]
+    #[arg(long, env, default_value_t = 11_229)]
     tpu_quic_fwd_port: u16,
 
     /// Bind IP address for GRPC server
-    #[clap(long, env, value_parser)]
+    #[arg(long, env, default_value_t = IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)))]
     grpc_bind_ip: IpAddr,
 
     /// Bind port address for GRPC server
-    #[clap(long, env, value_parser, default_value_t = 11_226)]
+    #[arg(long, env, default_value_t = 11_226)]
     grpc_bind_port: u16,
 
     /// Number of TPU threads
-    #[clap(long, env, value_parser, default_value_t = 32)]
+    #[arg(long, env, default_value_t = 32)]
     num_tpu_binds: usize,
 
     /// Number of TPU forward threads
-    #[clap(long, env, value_parser, default_value_t = 16)]
+    #[arg(long, env, default_value_t = 16)]
     num_tpu_fwd_binds: usize,
 
     /// RPC servers as a space-separated list. Shall be same position as websocket equivalent below
-    #[clap(long, env, value_parser, default_value = "http://127.0.0.1:8899")]
-    rpc_servers: String,
+    #[arg(
+        long,
+        env,
+        value_delimiter = ' ',
+        required = true,
+        default_value = "http://127.0.0.1:8899"
+    )]
+    rpc_servers: Vec<String>,
 
     /// Websocket servers as a space-separated list. Shall be same position as RPC equivalent above
-    #[clap(long, env, value_parser, default_value = "ws://127.0.0.1:8900")]
-    websocket_servers: String,
+    #[arg(
+        long,
+        env,
+        value_delimiter = ' ',
+        required = true,
+        default_value = "ws://127.0.0.1:8900"
+    )]
+    websocket_servers: Vec<String>,
 
     /// This is the IP address that will be shared with the validator. The validator will
     /// tell the rest of the network to send packets here.
-    #[clap(long, env, value_parser)]
+    #[arg(long, env)]
     public_ip: Option<IpAddr>,
 
     /// Packet delay in milliseconds
-    #[clap(long, env, value_parser, default_value_t = 200)]
+    #[arg(long, env, default_value_t = 200)]
     packet_delay_ms: u32,
 
     /// Block engine address
-    #[clap(long, env, value_parser)]
+    #[arg(long, env)]
     block_engine_url: String,
 
     /// Authentication service address of the block-engine. Keypairs are authenticated against the block engine
-    #[clap(long, env, value_parser)]
+    #[arg(long, env)]
     block_engine_auth_service_url: String,
 
     /// Keypair path
-    #[clap(long, env, value_parser)]
+    #[arg(long, env)]
     keypair_path: String,
 
-    /// Validators allowed to authenticate and connect to the relayer.
+    /// Validators allowed to authenticate and connect to the relayer, comma separated.
     /// If null then all validators on the leader schedule shall be permitted.
-    #[clap(long, env)]
-    allowed_validators: Option<Vec<String>>,
+    #[arg(long, env, value_delimiter = ',', value_parser = Pubkey::from_str)]
+    allowed_validators: Option<Vec<Pubkey>>,
 
     /// The private key used to sign tokens by this server.
-    #[clap(long, env)]
+    #[arg(long, env)]
     signing_key_pem_path: String,
 
     /// The public key used to verify tokens by this and other services.
-    #[clap(long, env)]
+    #[arg(long, env)]
     verifying_key_pem_path: String,
 
     /// Specifies how long access_tokens are valid for, expressed in seconds.
-    #[clap(long, env, default_value_t = 1800)]
+    #[arg(long, env, default_value_t = 1_800)]
     access_token_ttl_secs: i64,
 
     /// Specifies how long access_tokens are valid for, expressed in seconds.
-    #[clap(long, env, default_value_t = 180000)]
+    #[arg(long, env, default_value_t = 180_000)]
     refresh_token_ttl_secs: i64,
 
     /// Specifies how long challenges are valid for, expressed in seconds.
-    #[clap(long, env, default_value_t = 1800)]
+    #[arg(long, env, default_value_t = 1_800)]
     challenge_ttl_secs: i64,
 
     /// The interval at which challenges are checked for expiration.
-    #[clap(long, env, default_value_t = 180)]
+    #[arg(long, env, default_value_t = 180)]
     challenge_expiration_sleep_interval: i64,
 
     /// How long it takes to miss a slot for the system to be considered unhealthy
-    #[clap(long, env, default_value_t = 10)]
+    #[arg(long, env, default_value_t = 10)]
     missing_slot_unhealthy_secs: u64,
 
     /// Solana cluster name (mainnet-beta, testnet, devnet, ...)
-    #[clap(long, env)]
+    #[arg(long, env)]
     cluster: String,
 
     /// Region (amsterdam, dallas, frankfurt, ...)
-    #[clap(long, env)]
+    #[arg(long, env)]
     region: String,
 
     /// Accounts of interest cache TTL. Note this must play nicely with the refresh period that
     /// block engine uses to send full updates.
-    #[clap(long, env, default_value_t = 300)]
+    #[arg(long, env, default_value_t = 300)]
     aoi_cache_ttl_s: u64,
 
     /// How frequently to refresh the address lookup table accounts
-    #[clap(long, env, default_value_t = 30)]
+    #[arg(long, env, default_value_t = 30)]
     lookup_table_refresh_s: u64,
 }
 
+#[derive(Debug)]
 struct Sockets {
     tpu_sockets: TpuSockets,
     tpu_ip: IpAddr,
@@ -201,8 +213,8 @@ fn get_sockets(args: &Args) -> Sockets {
             transactions_quic_sockets: tpu_quic_sockets.pop().unwrap(),
             transactions_forwards_quic_sockets: tpu_fwd_quic_sockets.pop().unwrap(),
         },
-        tpu_ip: IpAddr::from_str("0.0.0.0").unwrap(),
-        tpu_fwd_ip: IpAddr::from_str("0.0.0.0").unwrap(),
+        tpu_ip: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        tpu_fwd_ip: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
     }
 }
 
@@ -230,42 +242,33 @@ fn main() {
     assert!(args.grpc_bind_ip.is_ipv4(), "must bind to IPV4 address");
 
     let sockets = get_sockets(&args);
+    info!("Relayer listening at: {sockets:?}");
 
     let keypair =
         Arc::new(read_keypair_file(args.keypair_path).expect("keypair file does not exist"));
-    solana_metrics::set_host_id(keypair.pubkey().to_string());
+    solana_metrics::set_host_id(format!(
+        "{}_{}",
+        hostname::get().unwrap().to_str().unwrap(), // hostname should follow RFC1123
+        keypair.pubkey()
+    ));
     info!("Relayer started with pubkey: {}", keypair.pubkey());
 
     let exit = graceful_panic(None);
 
-    let rpc_servers: Vec<String> = args.rpc_servers.split(' ').map(String::from).collect();
-    let websocket_servers: Vec<String> = args
-        .websocket_servers
-        .split(' ')
-        .map(String::from)
-        .collect();
-    info!("rpc servers: {:?}", rpc_servers);
-    info!("ws servers: {:?}", websocket_servers);
-
-    assert!(!rpc_servers.is_empty(), "num rpc servers >= 1");
     assert_eq!(
-        rpc_servers.len(),
-        websocket_servers.len(),
-        "num rpc servers = num websocket servers"
-    );
-    assert!(
-        args.missing_slot_unhealthy_secs > 0,
-        "need to provide non-zero check time"
+        args.rpc_servers.len(),
+        args.websocket_servers.len(),
+        "number of rpc servers must match number of websocket servers"
     );
 
-    let servers: Vec<(String, String)> = rpc_servers
+    let servers: Vec<(String, String)> = args
+        .rpc_servers
         .into_iter()
-        .zip(websocket_servers.into_iter())
+        .zip(args.websocket_servers.into_iter())
         .collect();
 
-    let (rpc_load_balancer, health_manager_slot_receiver) =
-        LoadBalancer::new(&servers, &exit, args.cluster.clone(), args.region.clone());
-    let rpc_load_balancer = Arc::new(Mutex::new(rpc_load_balancer));
+    let (rpc_load_balancer, slot_receiver) = LoadBalancer::new(&servers, &exit);
+    let rpc_load_balancer = Arc::new(rpc_load_balancer);
 
     // Lookup table refresher
     let address_lookup_table_cache: DashMap<Pubkey, AddressLookupTableAccount> = DashMap::new();
@@ -274,8 +277,6 @@ fn main() {
         &address_lookup_table_cache,
         args.lookup_table_refresh_s,
         &exit,
-        args.cluster.clone(),
-        args.region.clone(),
     );
 
     let (tpu, packet_receiver) = Tpu::new(
@@ -287,96 +288,84 @@ fn main() {
         &rpc_load_balancer,
     );
 
-    let leader_cache = LeaderScheduleCacheUpdater::new(
-        &rpc_load_balancer,
-        &exit,
-        args.cluster.clone(),
-        args.region.clone(),
-    );
+    let leader_cache = LeaderScheduleCacheUpdater::new(&rpc_load_balancer, &exit);
 
-    let (delay_sender, delay_receiver) = unbounded();
+    // receiver tracked as relayer_metrics.delay_packet_receiver_len
+    let (delay_packet_sender, delay_packet_receiver) =
+        crossbeam_channel::bounded(Tpu::TPU_QUEUE_CAPACITY);
 
     // NOTE: make sure the channel here isn't too big because it will get backed up
     // with packets when the block engine isn't connected
-    let (block_engine_sender, block_engine_receiver) = channel(1000);
+    // tracked as forwarder_metrics.block_engine_sender-len
+    let (block_engine_sender, block_engine_receiver) =
+        channel(jito_transaction_relayer::forwarder::BLOCK_ENGINE_FORWARDER_QUEUE_CAPACITY);
 
     let forward_and_delay_threads = start_forward_and_delay_thread(
         packet_receiver,
-        delay_sender,
+        delay_packet_sender,
         args.packet_delay_ms,
         block_engine_sender,
         1,
         &exit,
-        args.cluster.clone(),
-        args.region.clone(),
     );
     let block_engine_forwarder = BlockEngineRelayerHandler::new(
         args.block_engine_url,
         args.block_engine_auth_service_url,
         block_engine_receiver,
         keypair,
-        &exit,
-        args.cluster.clone(),
-        args.region.clone(),
+        exit.clone(),
         args.aoi_cache_ttl_s,
         address_lookup_table_cache,
     );
 
-    let (slot_sender, slot_receiver) = unbounded();
+    // receiver tracked as relayer_metrics.slot_receiver_len
+    // downstream channel gets data that was duplicated by HealthManager
+    let (downstream_slot_sender, downstream_slot_receiver) =
+        crossbeam_channel::bounded(LoadBalancer::SLOT_QUEUE_CAPACITY);
     let health_manager = HealthManager::new(
-        health_manager_slot_receiver,
-        slot_sender,
+        slot_receiver,
+        downstream_slot_sender,
         Duration::from_secs(args.missing_slot_unhealthy_secs),
-        &exit,
-        args.cluster.clone(),
-        args.region.clone(),
+        exit.clone(),
     );
 
     let server_addr = SocketAddr::new(args.grpc_bind_ip, args.grpc_bind_port);
     let relayer_svc = RelayerImpl::new(
-        slot_receiver,
-        delay_receiver,
+        downstream_slot_receiver,
+        delay_packet_receiver,
         leader_cache.handle(),
-        &exit,
         public_ip,
         args.tpu_port,
         args.tpu_fwd_port,
         health_manager.handle(),
-        args.cluster.clone(),
-        args.region.clone(),
+        exit.clone(),
     );
 
-    let mut buf = Vec::new();
-    File::open(args.signing_key_pem_path)
-        .expect("signing key file to be found")
-        .read_to_end(&mut buf)
-        .expect("to read signing key file");
+    let priv_key = fs::read(&args.signing_key_pem_path).unwrap_or_else(|_| {
+        panic!(
+            "Failed to read signing key file: {}",
+            &args.verifying_key_pem_path
+        )
+    });
     let signing_key = PKeyWithDigest {
         digest: MessageDigest::sha256(),
-        key: PKey::private_key_from_pem(&buf[..]).unwrap(),
+        key: PKey::private_key_from_pem(&priv_key).unwrap(),
     };
 
-    let mut buf = Vec::new();
-    File::open(args.verifying_key_pem_path)
-        .expect("verifying key file to be found")
-        .read_to_end(&mut buf)
-        .expect("to read verifying key file");
+    let key = fs::read(&args.verifying_key_pem_path).unwrap_or_else(|_| {
+        panic!(
+            "Failed to read verifying key file: {}",
+            &args.verifying_key_pem_path
+        )
+    });
     let verifying_key = Arc::new(PKeyWithDigest {
         digest: MessageDigest::sha256(),
-        key: PKey::public_key_from_pem(&buf[..]).unwrap(),
+        key: PKey::public_key_from_pem(&key).unwrap(),
     });
 
-    let validator_store = if let Some(pubkeys) = args.allowed_validators {
-        let pubkeys = pubkeys
-            .into_iter()
-            .map(|pk| {
-                Pubkey::from_str(&pk)
-                    .unwrap_or_else(|_| panic!("failed to parse pubkey from string: {pk}"))
-            })
-            .collect::<HashSet<Pubkey>>();
-        ValidatorStore::UserDefined(pubkeys)
-    } else {
-        ValidatorStore::LeaderSchedule(leader_cache.handle())
+    let validator_store = match args.allowed_validators {
+        Some(pubkeys) => ValidatorStore::UserDefined(HashSet::from_iter(pubkeys.into_iter())),
+        None => ValidatorStore::LeaderSchedule(leader_cache.handle()),
     };
 
     let rt = Builder::new_multi_thread().enable_all().build().unwrap();
@@ -464,12 +453,10 @@ impl ValidatorAuther for ValidatorAutherImpl {
 }
 
 fn start_lookup_table_refresher(
-    rpc_load_balancer: &Arc<Mutex<LoadBalancer>>,
+    rpc_load_balancer: &Arc<LoadBalancer>,
     lookup_table: &DashMap<Pubkey, AddressLookupTableAccount>,
     lookup_table_refresh_s: u64,
     exit: &Arc<AtomicBool>,
-    cluster: String,
-    region: String,
 ) -> JoinHandle<()> {
     let rpc_load_balancer = rpc_load_balancer.clone();
     let lookup_table = lookup_table.clone();
@@ -482,7 +469,7 @@ fn start_lookup_table_refresher(
 
             // seed lookup table
             if let Err(e) = refresh_address_lookup_table(&rpc_load_balancer, &lookup_table) {
-                error!("error refreshing address lookup table: {:?}", e);
+                error!("error refreshing address lookup table: {e:?}");
             }
 
             let tick_receiver = tick(Duration::from_secs(1));
@@ -490,67 +477,68 @@ fn start_lookup_table_refresher(
 
             while !exit.load(Ordering::Relaxed) {
                 let _ = tick_receiver.recv();
-
-                if last_refresh.elapsed() > refresh_duration {
-                    let now = Instant::now();
-                    let refresh_result =
-                        refresh_address_lookup_table(&rpc_load_balancer, &lookup_table);
-                    let updated_elapsed = now.elapsed().as_micros();
-                    match refresh_result {
-                        Ok(_) => {
-                            datapoint_info!("lookup_table_refresher-ok",
-                                "cluster" => cluster,
-                                "region" => region,
-                                ("count", 1, i64),
-                                ("lookup_table_size", lookup_table.len(), i64),
-                                ("updated_elapsed_us", updated_elapsed as u64, i64),
-                            );
-                        }
-                        Err(e) => {
-                            datapoint_error!("lookup_table_refresher-error",
-                                "cluster" => cluster,
-                                "region" => region,
-                                ("count", 1, i64),
-                                ("lookup_table_size", lookup_table.len(), i64),
-                                ("updated_elapsed_us", updated_elapsed as u64, i64),
-                                ("error", e.to_string(), String),
-                            );
-                        }
-                    }
-                    last_refresh = Instant::now();
+                if last_refresh.elapsed() < refresh_duration {
+                    continue;
                 }
+
+                let now = Instant::now();
+                let refresh_result =
+                    refresh_address_lookup_table(&rpc_load_balancer, &lookup_table);
+                let updated_elapsed = now.elapsed().as_micros();
+                match refresh_result {
+                    Ok(_) => {
+                        datapoint_info!(
+                            "lookup_table_refresher-ok",
+                            ("count", 1, i64),
+                            ("lookup_table_size", lookup_table.len(), i64),
+                            ("updated_elapsed_us", updated_elapsed, i64),
+                        );
+                    }
+                    Err(e) => {
+                        datapoint_error!(
+                            "lookup_table_refresher-error",
+                            ("count", 1, i64),
+                            ("lookup_table_size", lookup_table.len(), i64),
+                            ("updated_elapsed_us", updated_elapsed, i64),
+                            ("error", e.to_string(), String),
+                        );
+                    }
+                }
+                last_refresh = Instant::now();
             }
         })
         .unwrap()
 }
 
 fn refresh_address_lookup_table(
-    rpc_load_balancer: &Arc<Mutex<LoadBalancer>>,
+    rpc_load_balancer: &Arc<LoadBalancer>,
     lookup_table: &DashMap<Pubkey, AddressLookupTableAccount>,
 ) -> solana_client::client_error::Result<()> {
-    let rpc_client = rpc_load_balancer.lock().unwrap().rpc_client();
+    let rpc_client = rpc_load_balancer.rpc_client();
 
     let address_lookup_table =
         Pubkey::from_str("AddressLookupTab1e1111111111111111111111111").unwrap();
+    let start = Instant::now();
     let accounts = rpc_client.get_program_accounts(&address_lookup_table)?;
-    info!("loaded {} lookup tables", accounts.len());
+    info!(
+        "Fetched {} lookup tables from RPC in {:?}",
+        accounts.len(),
+        start.elapsed()
+    );
 
     let mut new_pubkeys = HashSet::new();
-    for (pubkey, account_data) in &accounts {
-        match AddressLookupTable::deserialize(account_data.data.as_slice()) {
+    for (pubkey, account_data) in accounts {
+        match AddressLookupTable::deserialize(&account_data.data) {
             Err(e) => {
-                error!("error deserializing AddressLookupTable pubkey: {pubkey} error: {e}");
+                error!("error deserializing AddressLookupTable pubkey: {pubkey}, error: {e}");
             }
             Ok(table) => {
-                debug!(
-                    "lookup table loaded pubkey: {:?} table: {:?}",
-                    pubkey, table
-                );
+                debug!("lookup table loaded pubkey: {pubkey:?}, table: {table:?}");
                 new_pubkeys.insert(pubkey);
                 lookup_table.insert(
-                    *pubkey,
+                    pubkey,
                     AddressLookupTableAccount {
-                        key: *pubkey,
+                        key: pubkey,
                         addresses: table.addresses.to_vec(),
                     },
                 );

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -391,7 +391,7 @@ fn main() {
                 AuthInterceptor::new(verifying_key.clone(), AlgorithmType::Rs256),
             ))
             .add_service(AuthServiceServer::new(auth_svc))
-            .serve_with_shutdown(server_addr, shutdown_signal())
+            .serve_with_shutdown(server_addr, shutdown_signal(exit.clone()))
             .await
             .expect("serve relayer");
     });
@@ -408,7 +408,7 @@ fn main() {
     block_engine_forwarder.join().unwrap();
 }
 
-pub async fn shutdown_signal() {
+pub async fn shutdown_signal(exit: Arc<AtomicBool>) {
     let ctrl_c = async {
         signal::ctrl_c()
             .await
@@ -430,7 +430,7 @@ pub async fn shutdown_signal() {
         _ = ctrl_c => {},
         _ = terminate => {},
     }
-
+    exit.store(true, Ordering::Relaxed);
     warn!("signal received, starting graceful shutdown");
 }
 

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -132,7 +132,7 @@ struct Args {
 
     /// Validators allowed to authenticate and connect to the relayer, comma separated.
     /// If null then all validators on the leader schedule shall be permitted.
-    #[arg(long, env, value_delimiter = ',', value_parser = Pubkey::from_str)]
+    #[arg(long, env, value_delimiter = ',')]
     allowed_validators: Option<Vec<Pubkey>>,
 
     /// The private key used to sign tokens by this server.
@@ -145,19 +145,19 @@ struct Args {
 
     /// Specifies how long access_tokens are valid for, expressed in seconds.
     #[arg(long, env, default_value_t = 1_800)]
-    access_token_ttl_secs: i64,
+    access_token_ttl_secs: u64,
 
     /// Specifies how long access_tokens are valid for, expressed in seconds.
     #[arg(long, env, default_value_t = 180_000)]
-    refresh_token_ttl_secs: i64,
+    refresh_token_ttl_secs: u64,
 
     /// Specifies how long challenges are valid for, expressed in seconds.
     #[arg(long, env, default_value_t = 1_800)]
-    challenge_ttl_secs: i64,
+    challenge_ttl_secs: u64,
 
     /// The interval at which challenges are checked for expiration.
     #[arg(long, env, default_value_t = 180)]
-    challenge_expiration_sleep_interval: i64,
+    challenge_expiration_sleep_interval_secs: u64,
 
     /// How long it takes to miss a slot for the system to be considered unhealthy
     #[arg(long, env, default_value_t = 10)]
@@ -174,11 +174,11 @@ struct Args {
     /// Accounts of interest cache TTL. Note this must play nicely with the refresh period that
     /// block engine uses to send full updates.
     #[arg(long, env, default_value_t = 300)]
-    aoi_cache_ttl_s: u64,
+    aoi_cache_ttl_secs: u64,
 
     /// How frequently to refresh the address lookup table accounts
     #[arg(long, env, default_value_t = 30)]
-    lookup_table_refresh_s: u64,
+    lookup_table_refresh_secs: u64,
 }
 
 #[derive(Debug)]
@@ -275,7 +275,7 @@ fn main() {
     let lookup_table_refresher = start_lookup_table_refresher(
         &rpc_load_balancer,
         &address_lookup_table_cache,
-        args.lookup_table_refresh_s,
+        args.lookup_table_refresh_secs,
         &exit,
     );
 
@@ -314,7 +314,7 @@ fn main() {
         block_engine_receiver,
         keypair,
         exit.clone(),
-        args.aoi_cache_ttl_s,
+        args.aoi_cache_ttl_secs,
         address_lookup_table_cache,
     );
 
@@ -376,10 +376,10 @@ fn main() {
             },
             signing_key,
             verifying_key.clone(),
-            Duration::from_secs(args.access_token_ttl_secs as u64),
-            Duration::from_secs(args.refresh_token_ttl_secs as u64),
-            Duration::from_secs(args.challenge_ttl_secs as u64),
-            Duration::from_secs(args.challenge_expiration_sleep_interval as u64),
+            Duration::from_secs(args.access_token_ttl_secs),
+            Duration::from_secs(args.refresh_token_ttl_secs),
+            Duration::from_secs(args.challenge_ttl_secs),
+            Duration::from_secs(args.challenge_expiration_sleep_interval_secs),
             &exit,
             health_manager.handle(),
         );

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -280,7 +280,7 @@ fn main() {
         &exit,
     );
 
-    let (tpu, packet_receiver) = Tpu::new(
+    let (tpu, verified_receiver) = Tpu::new(
         sockets.tpu_sockets,
         &exit,
         &keypair,
@@ -297,12 +297,12 @@ fn main() {
 
     // NOTE: make sure the channel here isn't too big because it will get backed up
     // with packets when the block engine isn't connected
-    // tracked as forwarder_metrics.block_engine_sender-len
+    // tracked as forwarder_metrics.block_engine_sender_len
     let (block_engine_sender, block_engine_receiver) =
         channel(jito_transaction_relayer::forwarder::BLOCK_ENGINE_FORWARDER_QUEUE_CAPACITY);
 
     let forward_and_delay_threads = start_forward_and_delay_thread(
-        packet_receiver,
+        verified_receiver,
         delay_packet_sender,
         args.packet_delay_ms,
         block_engine_sender,


### PR DESCRIPTION
Notes:
- Clippy fails due to missing protoc, fixed in https://github.com/jito-foundation/jito-relayer/pull/72

Changes:
- Log unbounded & large channel sizes
  - Convert to bounded channels after giving about 10x margin to peak usage
- Handle partially exited threads (use panic)
- Fix incorrect Dashmap cloning
- Remove unnecessary mutexes
- Backport ./b simplification
- Backport Dockerfile caching improvements
- Library updates
- Clap parsing cleanups
- Fix docker-compose start (missing params)
- Clean up redundant functions