### PR TITLE
Adds ofac transaction filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,7 +2239,9 @@ dependencies = [
 name = "jito-core"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "crossbeam-channel",
+ "dashmap 5.4.0",
  "jito-rpc",
  "lazy_static",
  "log",
@@ -3921,7 +3923,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -6106,7 +6108,7 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tungstenite",
  "webpki 0.22.0",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -6251,6 +6253,7 @@ dependencies = [
  "percent-encoding 2.2.0",
  "pin-project",
  "prost 0.11.9",
+ "rustls-native-certs",
  "rustls-pemfile 1.0.2",
  "tokio",
  "tokio-rustls 0.24.0",
@@ -6259,6 +6262,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 0.23.0",
 ]
 
 [[package]]
@@ -6405,7 +6409,7 @@ dependencies = [
  "url 2.3.1",
  "utf-8",
  "webpki 0.22.0",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -6727,6 +6731,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,8 @@ publish = false
 
 [dependencies]
 crossbeam-channel = "0.5.8"
+bincode = "1.3.3"
+dashmap = "5.4.0"
 jito-rpc = { path = "../rpc" }
 lazy_static = "1.4.0"
 log = "0.4.17"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
 use log::*;
 
 mod fetch_stage;
+pub mod ofac_stage;
 mod staked_nodes_updater_service;
 pub mod tpu;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 use log::*;
 
 mod fetch_stage;
-pub mod ofac_stage;
+mod ofac_stage;
 mod staked_nodes_updater_service;
 pub mod tpu;
 

--- a/core/src/ofac_stage.rs
+++ b/core/src/ofac_stage.rs
@@ -1,0 +1,394 @@
+use std::{
+    collections::HashSet,
+    thread,
+    thread::{Builder, JoinHandle},
+};
+
+use crossbeam_channel::{Receiver, Sender};
+use dashmap::DashMap;
+use log::warn;
+use solana_core::banking_stage::BankingPacketBatch;
+use solana_perf::packet::PacketBatch;
+use solana_sdk::{
+    address_lookup_table_account::AddressLookupTableAccount, pubkey::Pubkey,
+    transaction::VersionedTransaction,
+};
+
+pub struct OfacStage {
+    ofac_thread: JoinHandle<()>,
+}
+
+impl OfacStage {
+    pub fn new(
+        verified_receiver: Receiver<BankingPacketBatch>,
+        ofac_sender: Sender<BankingPacketBatch>,
+        ofac_addresses: &HashSet<Pubkey>,
+        address_lookup_table_cache: &DashMap<Pubkey, AddressLookupTableAccount>,
+    ) -> OfacStage {
+        let ofac_thread = if ofac_addresses.is_empty() {
+            Self::spawn_passthrough(verified_receiver, ofac_sender)
+        } else {
+            Self::spawn_ofac_thread(
+                verified_receiver,
+                ofac_sender,
+                ofac_addresses,
+                address_lookup_table_cache,
+            )
+        };
+        OfacStage { ofac_thread }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.ofac_thread.join()
+    }
+
+    fn spawn_passthrough(
+        verified_receiver: Receiver<BankingPacketBatch>,
+        ofac_sender: Sender<BankingPacketBatch>,
+    ) -> JoinHandle<()> {
+        Builder::new()
+            .name("ofac_stage".into())
+            .spawn(move || {
+                while let Ok(packets) = verified_receiver.recv() {
+                    if ofac_sender.send(packets).is_err() {
+                        warn!("ofac_sender send error, returning early");
+                        return;
+                    }
+                }
+                warn!("verified_receiver receive error, returning early");
+            })
+            .unwrap()
+    }
+
+    fn spawn_ofac_thread(
+        verified_receiver: Receiver<BankingPacketBatch>,
+        ofac_sender: Sender<BankingPacketBatch>,
+        ofac_addresses: &HashSet<Pubkey>,
+        address_lookup_table_cache: &DashMap<Pubkey, AddressLookupTableAccount>,
+    ) -> JoinHandle<()> {
+        let address_lookup_table_cache = address_lookup_table_cache.clone();
+        let ofac_addresses = ofac_addresses.clone();
+        Builder::new()
+            .name("ofac_stage".into())
+            .spawn(move || {
+                while let Ok(mut packets) = verified_receiver.recv() {
+                    packets.0.iter_mut().for_each(|packet_batch| {
+                        discard_ofac_packets(
+                            packet_batch,
+                            &ofac_addresses,
+                            &address_lookup_table_cache,
+                        );
+                    });
+
+                    if ofac_sender.send(packets).is_err() {
+                        warn!("ofac_sender send error, returning early");
+                        return;
+                    }
+                }
+            })
+            .unwrap()
+    }
+}
+
+/// Discards packets that mention any OFAC related transactions
+fn discard_ofac_packets(
+    packet_batch: &mut PacketBatch,
+    ofac_addresses: &HashSet<Pubkey>,
+    address_lookup_table_cache: &DashMap<Pubkey, AddressLookupTableAccount>,
+) {
+    for p in packet_batch.iter_mut().filter(|p| !p.meta.discard()) {
+        let tx: bincode::Result<VersionedTransaction> = p.deserialize_slice(..);
+        if let Ok(tx) = tx {
+            if is_tx_ofac_related(&tx, ofac_addresses, address_lookup_table_cache) {
+                p.meta.set_discard(true);
+            }
+        }
+    }
+}
+
+/// Returns true if transaction is ofac-related, false if not
+fn is_tx_ofac_related(
+    tx: &VersionedTransaction,
+    ofac_addresses: &HashSet<Pubkey>,
+    address_lookup_table_cache: &DashMap<Pubkey, AddressLookupTableAccount>,
+) -> bool {
+    is_ofac_address_in_static_keys(tx, ofac_addresses)
+        || is_ofac_address_in_lookup_table(tx, ofac_addresses, address_lookup_table_cache)
+}
+
+/// Returns true if an ofac address is in the static keys for an account
+fn is_ofac_address_in_static_keys(
+    tx: &VersionedTransaction,
+    ofac_addresses: &HashSet<Pubkey>,
+) -> bool {
+    tx.message
+        .static_account_keys()
+        .iter()
+        .any(|acc| ofac_addresses.contains(acc))
+}
+
+/// Returns true if an ofac address is in the dynamic keys (lookup table) for an account
+fn is_ofac_address_in_lookup_table(
+    tx: &VersionedTransaction,
+    ofac_addresses: &HashSet<Pubkey>,
+    address_lookup_table_cache: &DashMap<Pubkey, AddressLookupTableAccount>,
+) -> bool {
+    if let Some(lookup_tables) = tx.message.address_table_lookups() {
+        for table in lookup_tables {
+            if let Some(lookup_info) = address_lookup_table_cache.get(&table.account_key) {
+                for idx in table
+                    .writable_indexes
+                    .iter()
+                    .chain(table.readonly_indexes.iter())
+                {
+                    if let Some(account) = lookup_info.addresses.get(*idx as usize) {
+                        if ofac_addresses.contains(account) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use dashmap::DashMap;
+    use solana_perf::packet::PacketBatch;
+    use solana_sdk::{
+        address_lookup_table_account::AddressLookupTableAccount,
+        hash::Hash,
+        instruction::{AccountMeta, CompiledInstruction, Instruction},
+        message::{v0, v0::MessageAddressTableLookup, MessageHeader, VersionedMessage},
+        packet::Packet,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::keypair::Keypair,
+        transaction::{Transaction, VersionedTransaction},
+    };
+
+    use crate::ofac_stage::{
+        discard_ofac_packets, is_ofac_address_in_lookup_table, is_ofac_address_in_static_keys,
+    };
+
+    #[test]
+    fn test_is_ofac_address_in_static_keys() {
+        let ofac_pubkey = Pubkey::new_unique();
+        let ofac_addresses: HashSet<Pubkey> = HashSet::from_iter([ofac_pubkey.clone()]);
+
+        let payer = Keypair::new();
+
+        // random address passes
+        let tx = Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                Pubkey::new_unique(),
+                &[0],
+                vec![AccountMeta {
+                    pubkey: Pubkey::new_unique(),
+                    is_signer: false,
+                    is_writable: false,
+                }],
+            )],
+            Some(&payer.pubkey()),
+            &[&payer],
+            Hash::default(),
+        );
+        let tx = VersionedTransaction::from(tx);
+        assert!(!is_ofac_address_in_static_keys(&tx, &ofac_addresses));
+
+        // transaction with ofac account as writable
+        let tx = Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                Pubkey::new_unique(),
+                &[0],
+                vec![AccountMeta {
+                    pubkey: ofac_pubkey,
+                    is_signer: false,
+                    is_writable: true,
+                }],
+            )],
+            Some(&payer.pubkey()),
+            &[&payer],
+            Hash::default(),
+        );
+        let tx = VersionedTransaction::from(tx);
+        assert!(is_ofac_address_in_static_keys(&tx, &ofac_addresses));
+
+        // transaction with ofac account as readonly
+        let tx = Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                Pubkey::new_unique(),
+                &[0],
+                vec![AccountMeta {
+                    pubkey: ofac_pubkey,
+                    is_signer: false,
+                    is_writable: false,
+                }],
+            )],
+            Some(&payer.pubkey()),
+            &[&payer],
+            Hash::default(),
+        );
+        let tx = VersionedTransaction::from(tx);
+
+        assert!(is_ofac_address_in_static_keys(&tx, &ofac_addresses));
+    }
+
+    #[test]
+    fn test_is_ofac_address_in_lookup_table() {
+        let ofac_pubkey = Pubkey::new_unique();
+        let ofac_addresses: HashSet<Pubkey> = HashSet::from_iter([ofac_pubkey.clone()]);
+
+        let payer = Keypair::new();
+
+        let lookup_table_pubkey = Pubkey::new_unique();
+        let lookup_table = AddressLookupTableAccount {
+            key: lookup_table_pubkey.clone(),
+            addresses: vec![ofac_pubkey, Pubkey::new_unique()],
+        };
+
+        let address_lookup_table_cache = DashMap::from_iter([(lookup_table_pubkey, lookup_table)]);
+
+        // test read-only ofac address
+        let message = VersionedMessage::V0(v0::Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 0,
+            },
+            recent_blockhash: Hash::new_unique(),
+            account_keys: vec![payer.pubkey(), Pubkey::new_unique()],
+            address_table_lookups: vec![MessageAddressTableLookup {
+                account_key: lookup_table_pubkey,
+                writable_indexes: vec![],
+                readonly_indexes: vec![0],
+            }],
+            instructions: vec![CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![0],
+                data: vec![],
+            }],
+        });
+        let tx = VersionedTransaction::try_new(message, &[&payer]).expect("valid tx");
+
+        assert!(is_ofac_address_in_lookup_table(
+            &tx,
+            &ofac_addresses,
+            &address_lookup_table_cache
+        ));
+
+        // test writeable ofac
+        let message = VersionedMessage::V0(v0::Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 0,
+            },
+            recent_blockhash: Hash::new_unique(),
+            account_keys: vec![payer.pubkey(), Pubkey::new_unique()],
+            address_table_lookups: vec![MessageAddressTableLookup {
+                account_key: lookup_table_pubkey,
+                writable_indexes: vec![0],
+                readonly_indexes: vec![],
+            }],
+            instructions: vec![CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![0],
+                data: vec![],
+            }],
+        });
+        let tx = VersionedTransaction::try_new(message, &[&payer]).expect("valid tx");
+        assert!(is_ofac_address_in_lookup_table(
+            &tx,
+            &ofac_addresses,
+            &address_lookup_table_cache
+        ));
+
+        // test proximate ofac (in same lookup table, but not referenced)
+        let message = VersionedMessage::V0(v0::Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 0,
+            },
+            recent_blockhash: Hash::new_unique(),
+            account_keys: vec![payer.pubkey(), Pubkey::new_unique()],
+            address_table_lookups: vec![MessageAddressTableLookup {
+                account_key: lookup_table_pubkey,
+                writable_indexes: vec![1],
+                readonly_indexes: vec![],
+            }],
+            instructions: vec![CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![1],
+                data: vec![],
+            }],
+        });
+        let tx = VersionedTransaction::try_new(message, &[&payer]).expect("valid tx");
+        assert!(!is_ofac_address_in_lookup_table(
+            &tx,
+            &ofac_addresses,
+            &address_lookup_table_cache
+        ));
+    }
+
+    #[test]
+    fn test_discard_ofac_packets() {
+        let ofac_pubkey = Pubkey::new_unique();
+        let ofac_addresses: HashSet<Pubkey> = HashSet::from_iter([ofac_pubkey.clone()]);
+
+        let address_lookup_table_cache = DashMap::new();
+
+        let payer = Keypair::new();
+
+        // random address packet
+        let random_tx = Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                Pubkey::new_unique(),
+                &[0],
+                vec![AccountMeta {
+                    pubkey: Pubkey::new_unique(),
+                    is_signer: false,
+                    is_writable: false,
+                }],
+            )],
+            Some(&payer.pubkey()),
+            &[&payer],
+            Hash::default(),
+        );
+        let random_tx = VersionedTransaction::from(random_tx);
+        let random_packet = Packet::from_data(None, &random_tx).expect("can create packet");
+
+        let ofac_tx = Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                Pubkey::new_unique(),
+                &[0],
+                vec![AccountMeta {
+                    pubkey: ofac_pubkey,
+                    is_signer: false,
+                    is_writable: true,
+                }],
+            )],
+            Some(&payer.pubkey()),
+            &[&payer],
+            Hash::default(),
+        );
+        let ofac_tx = VersionedTransaction::from(ofac_tx);
+        let ofac_packet = Packet::from_data(None, &ofac_tx).expect("can create packet");
+
+        let mut packet_batch = PacketBatch::new(vec![random_packet, ofac_packet]);
+        discard_ofac_packets(
+            &mut packet_batch,
+            &ofac_addresses,
+            &address_lookup_table_cache,
+        );
+
+        assert_eq!(packet_batch.len(), 2);
+        assert!(!packet_batch[0].meta.discard());
+        assert!(packet_batch[1].meta.discard());
+    }
+}

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -66,7 +66,7 @@ impl Tpu {
         tpu_fwd_ip: &IpAddr,
         rpc_load_balancer: &Arc<LoadBalancer>,
         ofac_addresses: &HashSet<Pubkey>,
-        address_lookup_table_cache: &DashMap<Pubkey, AddressLookupTableAccount>,
+        address_lookup_table_cache: &Arc<DashMap<Pubkey, AddressLookupTableAccount>>,
     ) -> (Self, Receiver<BankingPacketBatch>) {
         let TpuSockets {
             transactions_quic_sockets,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -13,7 +13,7 @@ use std::{
     time::Duration,
 };
 
-use crossbeam_channel::{unbounded, Receiver};
+use crossbeam_channel::Receiver;
 use dashmap::DashMap;
 use jito_rpc::load_balancer::LoadBalancer;
 use solana_core::{
@@ -140,7 +140,7 @@ impl Tpu {
             "tpu-verifier",
         );
 
-        let (ofac_sender, ofac_receiver) = unbounded();
+        let (ofac_sender, ofac_receiver) = crossbeam_channel::bounded(Self::TPU_QUEUE_CAPACITY);
         let ofac_stage = OfacStage::new(
             verified_receiver,
             ofac_sender,

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -189,7 +189,7 @@ struct Args {
 
     /// Space-separated addresses to drop transactions for OFAC
     /// If any transaction mentions these addresses, the transaction will be dropped.
-    #[arg(long, env, value_delimiter = ',', value_parser = Pubkey::from_str)]
+    #[arg(long, env, value_delimiter = ' ', value_parser = Pubkey::from_str)]
     ofac_addresses: Option<Vec<Pubkey>>,
 }
 

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -187,10 +187,10 @@ struct Args {
     #[arg(long, env, default_value_t = 30)]
     lookup_table_refresh_secs: u64,
 
-    /// Space-separated addresses to drop transactions for (OFAC)
+    /// Space-separated addresses to drop transactions for OFAC
     /// If any transaction mentions these addresses, the transaction will be dropped.
-    #[arg(long, env)]
-    ofac_addresses: Option<String>,
+    #[arg(long, env, value_delimiter = ',', value_parser = Pubkey::from_str)]
+    ofac_addresses: Option<Vec<Pubkey>>,
 }
 
 #[derive(Debug)]
@@ -287,14 +287,10 @@ fn main() {
         .zip(args.websocket_servers.into_iter())
         .collect();
 
-    let ofac_addresses: HashSet<Pubkey> =
-        args.ofac_addresses
-            .map(|pubkeys| {
-                HashSet::from_iter(pubkeys.split(' ').map(|p| {
-                    Pubkey::from_str(p).expect(&format!("address {p} is not a valid pubkey"))
-                }))
-            })
-            .unwrap_or_default();
+    let ofac_addresses: HashSet<Pubkey> = args
+        .ofac_addresses
+        .map(|a| a.into_iter().collect())
+        .unwrap_or_default();
     info!("ofac addresses: {:?}", ofac_addresses);
 
     let (rpc_load_balancer, slot_receiver) = LoadBalancer::new(&servers, &exit);
@@ -305,7 +301,7 @@ fn main() {
         Arc::new(DashMap::new());
     let lookup_table_refresher = start_lookup_table_refresher(
         &rpc_load_balancer,
-        address_lookup_table_cache.clone(),
+        &address_lookup_table_cache,
         Duration::from_secs(args.lookup_table_refresh_secs),
         &exit,
     );
@@ -488,12 +484,13 @@ impl ValidatorAuther for ValidatorAutherImpl {
 
 fn start_lookup_table_refresher(
     rpc_load_balancer: &Arc<LoadBalancer>,
-    lookup_table: Arc<DashMap<Pubkey, AddressLookupTableAccount>>,
+    lookup_table: &Arc<DashMap<Pubkey, AddressLookupTableAccount>>,
     refresh_duration: Duration,
     exit: &Arc<AtomicBool>,
 ) -> JoinHandle<()> {
     let rpc_load_balancer = rpc_load_balancer.clone();
     let exit = exit.clone();
+    let lookup_table = lookup_table.clone();
 
     thread::Builder::new()
         .name("lookup_table_refresher".to_string())


### PR DESCRIPTION
- Institutional and US customers have requested a special relayer to filter OFAC transactions.
- This marks packets that mention OFAC addresses that are marked readonly or writeable for discard.
- If there's no OFAC addresses, the OFAC stage simply passes packets through