### PR TITLE
Add per validator packet forwarding metrics

### DIFF
--- a/relayer/src/relayer.rs
+++ b/relayer/src/relayer.rs
@@ -145,7 +145,7 @@ impl RelayerMetrics {
     }
 
     fn report(&self) {
-        for (pubkey, stats) in self.packet_stats_per_validator {
+        for (pubkey, stats) in &self.packet_stats_per_validator {
             datapoint_info!("relayer_validator_metrics",
                 "pubkey" => pubkey.to_string(),
                 ("num_packets_forwarded", stats.num_packets_forwarded, i64),


### PR DESCRIPTION
- We don't currently have insight into where packets are being forwarded.
- This PR adds the ability to export metrics on where packets are going on a per-validator basis