### PR TITLE
Make the packet processing filtering faster

### DIFF
--- a/jito-protos/src/convert.rs
+++ b/jito-protos/src/convert.rs
@@ -1,7 +1,4 @@
-use std::cmp::min;
-
-use solana_perf::packet::{Packet, PACKET_DATA_SIZE};
-use solana_sdk::transaction::VersionedTransaction;
+use solana_perf::packet::Packet;
 
 use crate::packet::{Meta as ProtoMeta, Packet as ProtoPacket, PacketFlags as ProtoPacketFlags};
 
@@ -22,16 +19,4 @@ pub fn packet_to_proto_packet(p: &Packet) -> Option<ProtoPacket> {
             sender_stake: p.meta.sender_stake,
         }),
     })
-}
-
-/// Converts a protobuf packet to a VersionedTransaction
-pub fn versioned_tx_from_packet(p: &ProtoPacket) -> Option<VersionedTransaction> {
-    let mut data = [0; PACKET_DATA_SIZE];
-    let copy_len = min(data.len(), p.data.len());
-    data[..copy_len].copy_from_slice(&p.data[..copy_len]);
-    let mut packet = Packet::new(data, Default::default());
-    if let Some(meta) = &p.meta {
-        packet.meta.size = meta.size as usize;
-    }
-    packet.deserialize_slice(..).ok()
 }


### PR DESCRIPTION
- Don't do packet -> proto packet -> packet -> versioned tx.
- Do packet -> versioned tx and if filtered, convert to proto packet