### PR TITLE
Use geyser table for lookup table updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2230,7 +2230,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic 0.8.3",
 ]
 
 [[package]]
@@ -2257,6 +2257,23 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "jito-geyser-protos"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f826617f59b4ffe437d28be1617da2b71fadb6b8f22f875cd2f65822d00f65c"
+dependencies = [
+ "bincode",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "serde",
+ "solana-account-decoder",
+ "solana-sdk",
+ "solana-transaction-status",
+ "tonic 0.8.3",
+ "tonic-build 0.8.4",
 ]
 
 [[package]]
@@ -2290,8 +2307,8 @@ dependencies = [
  "prost-types 0.11.9",
  "solana-perf",
  "solana-sdk",
- "tonic 0.9.2",
- "tonic-build 0.9.2",
+ "tonic 0.8.3",
+ "tonic-build 0.8.4",
 ]
 
 [[package]]
@@ -2319,7 +2336,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic 0.8.3",
 ]
 
 [[package]]
@@ -2362,6 +2379,7 @@ dependencies = [
  "itertools",
  "jito-block-engine",
  "jito-core",
+ "jito-geyser-protos",
  "jito-protos",
  "jito-relayer",
  "jito-relayer-web",
@@ -2382,7 +2400,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic 0.8.3",
 ]
 
 [[package]]
@@ -3933,7 +3951,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.22.6",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -4044,18 +4062,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki",
- "sct 0.7.0",
-]
-
-[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4083,16 +4089,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -6061,16 +6057,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
-dependencies = [
- "rustls 0.21.1",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6094,7 +6080,7 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tungstenite",
  "webpki 0.22.0",
- "webpki-roots 0.22.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -6206,6 +6192,7 @@ dependencies = [
  "pin-project",
  "prost 0.11.9",
  "prost-derive 0.11.9",
+ "rustls-native-certs",
  "rustls-pemfile 1.0.2",
  "tokio",
  "tokio-rustls 0.23.4",
@@ -6216,39 +6203,7 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
-]
-
-[[package]]
-name = "tonic"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.18",
- "base64 0.21.0",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding 2.2.0",
- "pin-project",
- "prost 0.11.9",
- "rustls-native-certs",
- "rustls-pemfile 1.0.2",
- "tokio",
- "tokio-rustls 0.24.0",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "webpki-roots 0.23.0",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -6268,19 +6223,6 @@ name = "tonic-build"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
-dependencies = [
- "prettyplease",
- "proc-macro2 1.0.58",
- "prost-build 0.11.9",
- "quote 1.0.27",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
  "prettyplease",
  "proc-macro2 1.0.58",
@@ -6414,7 +6356,7 @@ dependencies = [
  "url 2.3.1",
  "utf-8",
  "webpki 0.22.0",
- "webpki-roots 0.22.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -6736,15 +6678,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki 0.22.0",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
-dependencies = [
- "rustls-webpki",
 ]
 
 [[package]]

--- a/block_engine/Cargo.toml
+++ b/block_engine/Cargo.toml
@@ -19,4 +19,4 @@ solana-sdk = "=1.14.18"
 thiserror = "1.0.40"
 tokio = { version = "~1.14.1", features = ["rt-multi-thread"] }
 tokio-stream = "0.1.12"
-tonic = { version = "0.9.2", features = ["tls", "tls-roots", "tls-webpki-roots"] }
+tonic = { version = "0.8.3", features = ["tls", "tls-roots", "tls-webpki-roots"] }

--- a/block_engine/src/block_engine.rs
+++ b/block_engine/src/block_engine.rs
@@ -36,7 +36,7 @@ use thiserror::Error;
 use tokio::{
     select,
     sync::mpsc::{channel, Receiver, Sender},
-    task::JoinHandle,
+    task::{JoinError, JoinHandle},
     time::{interval, sleep},
 };
 use tokio_stream::wrappers::ReceiverStream;
@@ -91,7 +91,7 @@ pub type BlockEngineResult<T> = Result<T, BlockEngineError>;
 
 /// Attempts to maintain a connection to a Block Engine and forward packets to it
 pub struct BlockEngineRelayerHandler {
-    _task: JoinHandle<()>,
+    task: JoinHandle<()>,
 }
 
 impl BlockEngineRelayerHandler {
@@ -138,7 +138,11 @@ impl BlockEngineRelayerHandler {
             }
         });
 
-        BlockEngineRelayerHandler { _task: task }
+        BlockEngineRelayerHandler { task }
+    }
+
+    pub async fn join(self) -> Result<(), JoinError> {
+        self.task.await
     }
 
     /// Relayers are whitelisted in the block engine. In order to auth, a challenge-response handshake

--- a/jito-protos/Cargo.toml
+++ b/jito-protos/Cargo.toml
@@ -10,7 +10,7 @@ prost = "0.11.9"
 prost-types = "0.11.9"
 solana-perf = "=1.14.18"
 solana-sdk = "=1.14.18"
-tonic = "0.9.2"
+tonic = "0.8.3"
 
 [build-dependencies]
-tonic-build = "0.9.2"
+tonic-build = "0.8.4"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -29,4 +29,4 @@ solana-sdk = "=1.14.18"
 thiserror = "1.0.40"
 tokio = { version = "~1.14.1" }
 tokio-stream = "0.1.12"
-tonic = "0.9.2"
+tonic = "0.8.3"

--- a/relayer/src/relayer.rs
+++ b/relayer/src/relayer.rs
@@ -527,6 +527,7 @@ impl RelayerImpl {
             .filter_map(|pubkey| {
                 let sender = l_subscriptions.get(pubkey)?;
 
+                // NOTE: this check is important to avoid divide by zero error inside the validator's sigverify
                 if proto_packet_batch.packets.is_empty() {
                     return None;
                 }

--- a/relayer/src/schedule_cache.rs
+++ b/relayer/src/schedule_cache.rs
@@ -122,6 +122,8 @@ impl LeaderScheduleCacheUpdater {
     ) -> bool {
         let rpc_client = load_balancer.rpc_client();
 
+        // TODO (LB): do smart refreshing when epoch rolls over
+
         if let Ok(epoch_info) =
             rpc_client.get_epoch_info_with_commitment(CommitmentConfig::finalized())
         {

--- a/rpc/src/load_balancer.rs
+++ b/rpc/src/load_balancer.rs
@@ -43,7 +43,7 @@ impl LoadBalancer {
                 server_to_slot,
                 servers: servers
                     .iter()
-                    .map(|(http, ws)| (http.to_string(), ws.to_string()))
+                    .map(|(http, ws)| (ws.to_string(), http.to_string()))
                     .collect(),
                 subscription_threads,
             },

--- a/rpc/src/load_balancer.rs
+++ b/rpc/src/load_balancer.rs
@@ -154,7 +154,7 @@ impl LoadBalancer {
             .unwrap()
             .value()
             .to_string();
-        RpcClient::new(rpc_url)
+        RpcClient::new_with_commitment(rpc_url, CommitmentConfig::processed())
     }
 
     /// Returns a new non-blocking RPC client with the highest slot

--- a/transaction-relayer/Cargo.toml
+++ b/transaction-relayer/Cargo.toml
@@ -17,6 +17,7 @@ h2 = "=0.3.18" # CVE-2023-26964
 hostname = "0.3"
 itertools = "0.10.5"
 jito-block-engine = { path = "../block_engine" }
+jito-geyser-protos = "0.0.2"
 jito-core = { path = "../core" }
 jito-protos = { path = "../jito-protos" }
 jito-relayer = { path = "../relayer" }
@@ -38,4 +39,4 @@ solana-sdk = "=1.14.18"
 tikv-jemallocator = { version = "0.5", features = ["profiling"] }
 tokio = { version = "~1.14.1", features = ["rt-multi-thread"] }
 tokio-stream = "0.1.12"
-tonic = "0.9.2"
+tonic = { version = "0.8.3", features = ["tls", "tls-roots", "tls-webpki-roots"] }

--- a/transaction-relayer/src/lib.rs
+++ b/transaction-relayer/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod forwarder;
+pub mod lookup_table;

--- a/transaction-relayer/src/lookup_table.rs
+++ b/transaction-relayer/src/lookup_table.rs
@@ -110,8 +110,11 @@ async fn geyser_lookup_table_updater(
     let address_lookup_table =
         Pubkey::from_str("AddressLookupTab1e1111111111111111111111111").unwrap();
     loop {
+        info!("connecting to geyser to refresh account lookup tables");
+
         match get_geyser_client(&geyser_url, &geyser_access_token).await {
             Ok(mut geyser_client) => {
+                info!("subscribing to geyser account updates");
                 match geyser_client
                     .subscribe_account_updates(SubscribeAccountUpdatesRequest {
                         accounts: vec![address_lookup_table.to_bytes().to_vec()],
@@ -119,6 +122,8 @@ async fn geyser_lookup_table_updater(
                     .await
                 {
                     Ok(stream) => {
+                        info!("streaming account updates from geyser");
+
                         if let Err(e) =
                             update_lookup_table_from_stream(stream, &lookup_table_cache).await
                         {

--- a/transaction-relayer/src/lookup_table.rs
+++ b/transaction-relayer/src/lookup_table.rs
@@ -1,0 +1,239 @@
+use std::{
+    collections::HashSet,
+    str::FromStr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use dashmap::DashMap;
+use jito_geyser_protos::solana::geyser::{
+    geyser_client::GeyserClient, SubscribeAccountUpdatesRequest, TimestampedAccountUpdate,
+};
+use jito_rpc::load_balancer::LoadBalancer;
+use log::{debug, error, info, warn};
+use solana_address_lookup_table_program::state::AddressLookupTable;
+use solana_metrics::{datapoint_error, datapoint_info};
+use solana_program::{address_lookup_table_account::AddressLookupTableAccount, pubkey::Pubkey};
+use tokio::time::{interval, sleep};
+use tokio_stream::StreamExt;
+use tonic::{
+    codegen::InterceptedService,
+    service::Interceptor,
+    transport::{Channel, ClientTlsConfig, Endpoint, Error},
+    Response, Status, Streaming,
+};
+
+#[derive(Clone)]
+pub struct GrpcInterceptor {
+    pub access_token: String,
+}
+
+impl Interceptor for GrpcInterceptor {
+    fn call(&mut self, mut request: tonic::Request<()>) -> Result<tonic::Request<()>, Status> {
+        request
+            .metadata_mut()
+            .insert("access-token", self.access_token.parse().unwrap());
+        Ok(request)
+    }
+}
+
+async fn get_geyser_client(
+    geyser_grpc_addr: &str,
+    maybe_geyser_access_token: &Option<String>,
+) -> Result<GeyserClient<InterceptedService<Channel, GrpcInterceptor>>, Error> {
+    let geyser_grpc_channel = if geyser_grpc_addr.contains("https") {
+        Endpoint::from_str(geyser_grpc_addr)
+            .unwrap()
+            .tls_config(ClientTlsConfig::new())
+            .unwrap()
+            .connect()
+            .await?
+    } else {
+        Endpoint::from_str(geyser_grpc_addr)
+            .unwrap()
+            .connect()
+            .await?
+    };
+    let interceptor = GrpcInterceptor {
+        access_token: maybe_geyser_access_token.clone().unwrap_or_default(),
+    };
+
+    Ok(GeyserClient::with_interceptor(
+        geyser_grpc_channel,
+        interceptor,
+    ))
+}
+
+async fn update_lookup_table_from_stream(
+    stream: Response<Streaming<TimestampedAccountUpdate>>,
+    lookup_table_cache: &Arc<DashMap<Pubkey, AddressLookupTableAccount>>,
+) -> Result<(), String> {
+    let mut s = stream.into_inner();
+    while let Some(next_message) = s.next().await {
+        let timestamped_account_update = next_message.map_err(|e| e.to_string())?;
+        let account_update = timestamped_account_update
+            .account_update
+            .ok_or_else(|| "missing account in update".to_string())?;
+        let pubkey = Pubkey::try_from(account_update.pubkey)
+            .map_err(|_| "bad public key in account update".to_string())?;
+        let lookup_table = AddressLookupTable::deserialize(&account_update.data)
+            .map_err(|_| "bad address lookup table written".to_string())?;
+
+        info!(
+            "new lookup table update: {:?} num addresses: {:?}",
+            pubkey,
+            lookup_table.addresses.len()
+        );
+
+        lookup_table_cache.insert(
+            pubkey,
+            AddressLookupTableAccount {
+                key: pubkey,
+                addresses: lookup_table.addresses.to_vec(),
+            },
+        );
+    }
+    Ok(())
+}
+
+async fn geyser_lookup_table_updater(
+    geyser_url: String,
+    geyser_access_token: Option<String>,
+    lookup_table_cache: Arc<DashMap<Pubkey, AddressLookupTableAccount>>,
+) {
+    let address_lookup_table =
+        Pubkey::from_str("AddressLookupTab1e1111111111111111111111111").unwrap();
+    loop {
+        match get_geyser_client(&geyser_url, &geyser_access_token).await {
+            Ok(mut geyser_client) => {
+                match geyser_client
+                    .subscribe_account_updates(SubscribeAccountUpdatesRequest {
+                        accounts: vec![address_lookup_table.to_bytes().to_vec()],
+                    })
+                    .await
+                {
+                    Ok(stream) => {
+                        if let Err(e) =
+                            update_lookup_table_from_stream(stream, &lookup_table_cache).await
+                        {
+                            error!("error streaming from lookup table: {:?}", e);
+                        }
+                    }
+                    Err(e) => {
+                        warn!("error connecting to geyser: {:?}", e);
+                        sleep(Duration::from_secs(2)).await;
+                    }
+                }
+            }
+            Err(e) => {
+                error!("error connecting to geyser: {:?}", e);
+            }
+        }
+    }
+}
+
+pub async fn start_lookup_table_refresher(
+    rpc_load_balancer: Arc<LoadBalancer>,
+    lookup_table: Arc<DashMap<Pubkey, AddressLookupTableAccount>>,
+    refresh_duration: Duration,
+    exit: Arc<AtomicBool>,
+    geyser_url: Option<String>,
+    geyser_access_token: Option<String>,
+) {
+    let rpc_load_balancer = rpc_load_balancer.clone();
+    let exit = exit.clone();
+    let lookup_table = lookup_table.clone();
+    // seed lookup table
+    if let Err(e) = refresh_address_lookup_table(&rpc_load_balancer, &lookup_table).await {
+        error!("error refreshing address lookup table: {e:?}");
+    }
+
+    if geyser_url.is_some() {
+        tokio::spawn(geyser_lookup_table_updater(
+            geyser_url.unwrap(),
+            geyser_access_token,
+            lookup_table.clone(),
+        ));
+    }
+
+    let mut tick = interval(Duration::from_secs(1));
+    let mut last_refresh = Instant::now();
+
+    while !exit.load(Ordering::Relaxed) {
+        let _ = tick.tick().await;
+        if last_refresh.elapsed() < refresh_duration {
+            continue;
+        }
+
+        let now = Instant::now();
+        let refresh_result = refresh_address_lookup_table(&rpc_load_balancer, &lookup_table).await;
+        let updated_elapsed = now.elapsed().as_micros();
+        match refresh_result {
+            Ok(_) => {
+                datapoint_info!(
+                    "lookup_table_refresher-ok",
+                    ("count", 1, i64),
+                    ("lookup_table_size", lookup_table.len(), i64),
+                    ("updated_elapsed_us", updated_elapsed, i64),
+                );
+            }
+            Err(e) => {
+                datapoint_error!(
+                    "lookup_table_refresher-error",
+                    ("count", 1, i64),
+                    ("lookup_table_size", lookup_table.len(), i64),
+                    ("updated_elapsed_us", updated_elapsed, i64),
+                    ("error", e.to_string(), String),
+                );
+            }
+        }
+        last_refresh = Instant::now();
+    }
+}
+
+pub async fn refresh_address_lookup_table(
+    rpc_load_balancer: &Arc<LoadBalancer>,
+    lookup_table: &DashMap<Pubkey, AddressLookupTableAccount>,
+) -> solana_client::client_error::Result<()> {
+    let rpc_client = rpc_load_balancer.non_blocking_rpc_client();
+
+    let address_lookup_table =
+        Pubkey::from_str("AddressLookupTab1e1111111111111111111111111").unwrap();
+    let start = Instant::now();
+    let accounts = rpc_client
+        .get_program_accounts(&address_lookup_table)
+        .await?;
+    info!(
+        "Fetched {} lookup tables from RPC in {:?}",
+        accounts.len(),
+        start.elapsed()
+    );
+
+    let mut new_pubkeys = HashSet::new();
+    for (pubkey, account_data) in accounts {
+        match AddressLookupTable::deserialize(&account_data.data) {
+            Err(e) => {
+                error!("error deserializing AddressLookupTable pubkey: {pubkey}, error: {e}");
+            }
+            Ok(table) => {
+                debug!("lookup table loaded pubkey: {pubkey:?}, table: {table:?}");
+                new_pubkeys.insert(pubkey);
+                lookup_table.insert(
+                    pubkey,
+                    AddressLookupTableAccount {
+                        key: pubkey,
+                        addresses: table.addresses.to_vec(),
+                    },
+                );
+            }
+        }
+    }
+
+    // remove all the closed lookup tables
+    lookup_table.retain(|pubkey, _| new_pubkeys.contains(pubkey));
+
+    Ok(())
+}

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -428,7 +428,7 @@ fn main() {
     ));
 
     rt.block_on(async {
-        let _block_engine_relayer_handle = BlockEngineRelayerHandler::new(
+        let block_engine_relayer_handle = BlockEngineRelayerHandler::new(
             args.block_engine_url.clone(),
             args.block_engine_auth_service_url
                 .unwrap_or(args.block_engine_url),
@@ -438,7 +438,8 @@ fn main() {
             args.aoi_cache_ttl_secs,
             &address_lookup_table_cache,
             &is_connected_to_block_engine,
-        );
+        )
+        .await;
 
         let auth_svc = AuthServiceImpl::new(
             ValidatorAutherImpl {
@@ -464,6 +465,7 @@ fn main() {
             .serve_with_shutdown(server_addr, shutdown_signal(exit.clone()))
             .await
             .expect("serve relayer");
+        block_engine_relayer_handle.join().await.unwrap();
     });
 
     exit.store(true, Ordering::Relaxed);


### PR DESCRIPTION
- Move some more things into our runtime
- It's been hypothesized that increased traffic from frequent getPA calls against something that returns ~32ks account could result in worse performance for validators. In order to minimize this traffic, I've added updating lookup tables from geyser, specifically Jito's flavor of Geyser. In order to see much more reduced traffic, one should update the lookup table refresh period to be much longer than it currently is.