### PR TITLE
Send smaller packet sizes

### DIFF
--- a/relayer/src/relayer.rs
+++ b/relayer/src/relayer.rs
@@ -596,6 +596,7 @@ impl RelayerImpl {
         relayer_metrics: &mut RelayerMetrics,
     ) -> RelayerResult<()> {
         *highest_slot = maybe_slot?;
+        datapoint_info!("relayer-highest_slot", ("slot", *highest_slot as i64, i64));
         relayer_metrics.highest_slot = *highest_slot;
         Ok(())
     }

--- a/relayer/src/relayer.rs
+++ b/relayer/src/relayer.rs
@@ -519,6 +519,12 @@ impl RelayerImpl {
                 })
                 .collect(),
         };
+        if proto_packet_batch.packets.len() > 30 {
+            info!(
+                "proto_packet_batch num packets: {}",
+                proto_packet_batch.packets.len()
+            );
+        }
 
         let l_subscriptions = subscriptions.read().unwrap();
 
@@ -527,6 +533,8 @@ impl RelayerImpl {
             .filter_map(|pubkey| {
                 let sender = l_subscriptions.get(pubkey)?;
 
+                // NOTE: this is important to avoid divide-by-0 inside the validator if packets
+                // get routed to sigverify under the assumption theres > 0 packets in the batch
                 if proto_packet_batch.packets.is_empty() {
                     return None;
                 }

--- a/relayer/src/relayer.rs
+++ b/relayer/src/relayer.rs
@@ -520,8 +520,8 @@ impl RelayerImpl {
 
         let mut failed_forwards = Vec::new();
         for pubkey in slot_leaders {
-            for batch in &proto_packet_batches {
-                if let Some(sender) = l_subscriptions.get(&pubkey) {
+            if let Some(sender) = l_subscriptions.get(&pubkey) {
+                for batch in &proto_packet_batches {
                     // NOTE: this is important to avoid divide-by-0 inside the validator if packets
                     // get routed to sigverify under the assumption theres > 0 packets in the batch
                     if batch.packets.is_empty() {
@@ -547,6 +547,7 @@ impl RelayerImpl {
                         Err(TrySendError::Closed(_)) => {
                             error!("channel is closed for pubkey: {:?}", pubkey);
                             failed_forwards.push(pubkey);
+                            break;
                         }
                     }
                 }

--- a/transaction-relayer/src/forwarder.rs
+++ b/transaction-relayer/src/forwarder.rs
@@ -66,9 +66,9 @@ pub fn start_forward_and_delay_thread(
                         match verified_receiver.recv_timeout(SLEEP_DURATION) {
                             Ok(banking_packet_batch) => {
                                 let mut packet_batches = banking_packet_batch.0;
-                                while let Ok((batches, _)) = verified_receiver.try_recv() {
-                                    packet_batches.extend(batches.into_iter());
-                                }
+                                // while let Ok((batches, _)) = verified_receiver.try_recv() {
+                                //     packet_batches.extend(batches.into_iter());
+                                // }
 
                                 let total_packets: u64 =
                                     packet_batches.iter().map(|b| b.len() as u64).sum();

--- a/transaction-relayer/src/forwarder.rs
+++ b/transaction-relayer/src/forwarder.rs
@@ -65,10 +65,7 @@ pub fn start_forward_and_delay_thread(
 
                         match verified_receiver.recv_timeout(SLEEP_DURATION) {
                             Ok(banking_packet_batch) => {
-                                let mut packet_batches = banking_packet_batch.0;
-                                // while let Ok((batches, _)) = verified_receiver.try_recv() {
-                                //     packet_batches.extend(batches.into_iter());
-                                // }
+                                let packet_batches = banking_packet_batch.0;
 
                                 let total_packets: u64 =
                                     packet_batches.iter().map(|b| b.len() as u64).sum();


### PR DESCRIPTION
- Send smaller packet sizes from relayer to validator in order to minimize large chunk size payloads hitting the validator