### PR TITLE
Fix Rpc Url Parsing

### DIFF
--- a/rpc/src/load_balancer.rs
+++ b/rpc/src/load_balancer.rs
@@ -80,8 +80,8 @@ impl LoadBalancer {
             .iter()
             .map(|(_, websocket_url)| {
                 let ws_url_no_token = websocket_url
-                    .split('?')
-                    .next()
+                    .split('/')
+                    .nth(2)
                     .unwrap_or_default()
                     .to_string();
                 let exit = exit.clone();

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -101,7 +101,6 @@ struct Args {
         long,
         env,
         value_delimiter = ' ',
-        required = true,
         default_value = "http://127.0.0.1:8899"
     )]
     rpc_servers: Vec<String>,
@@ -111,7 +110,6 @@ struct Args {
         long,
         env,
         value_delimiter = ' ',
-        required = true,
         default_value = "ws://127.0.0.1:8900"
     )]
     websocket_servers: Vec<String>,


### PR DESCRIPTION
- Current RPC URL parsing creates bad metrics labeling. 
- Usage of default RPC URLs was broken from unnecessary "required" flag.