### PR TITLE
Assert public ip is ipv4

### DIFF
--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -263,7 +263,7 @@ fn main() {
     info!("public ip: {:?}", public_ip);
     assert!(
         public_ip.is_ipv4(),
-        "Your public IP address needs to be IPV4 but is currently listed as {}. \
+        "Your public IP address needs to be IPv4 but is currently listed as {}. \
     If you are seeing this error and not passing in --public-ip, \
     please find your public ip address and pass it in on the command line",
         public_ip
@@ -272,7 +272,7 @@ fn main() {
     // Supporting IPV6 addresses is a DOS vector since they are cheap and there's a much larger amount of them.
     // The DOS is specifically with regards to the challenges queue filling up and starving other legitimate
     // challenge requests.
-    assert!(args.grpc_bind_ip.is_ipv4(), "must bind to IPV4 address");
+    assert!(args.grpc_bind_ip.is_ipv4(), "must bind to IPv4 address");
 
     let sockets = get_sockets(&args);
     info!("Relayer listening at: {sockets:?}");

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -261,6 +261,13 @@ fn main() {
         response.parse().unwrap()
     };
     info!("public ip: {:?}", public_ip);
+    assert!(
+        public_ip.is_ipv4(),
+        "Your public IP address needs to be IPV4 but is currently listed as {}. \
+    If you are seeing this error and not passing in --public-ip, \
+    please find your public ip address and pass it in on the command line",
+        public_ip
+    );
 
     // Supporting IPV6 addresses is a DOS vector since they are cheap and there's a much larger amount of them.
     // The DOS is specifically with regards to the challenges queue filling up and starving other legitimate


### PR DESCRIPTION
Problem:
- When running a GET request against ifconfig.me, sometimes the service returns an IPv6 address.
- This IP address is passed to the validator and the validator attempts to parse it as IPv4.

Fix:
- This fix asserts the IP address is IPv4 with detailed instructions on how to fix it.

Longer term, need to look at IP address providers that provide an option to only get IPv4 addresses back.