### PR TITLE
Add FORWARD_ALL Option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2068,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -3422,9 +3422,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.59"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if 1.0.0",
@@ -3463,9 +3463,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.95"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -4728,9 +4728,9 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -8155,18 +8155,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/relayer/src/relayer.rs
+++ b/relayer/src/relayer.rs
@@ -691,19 +691,13 @@ impl RelayerImpl {
                 continue;
             }
 
-            let senders = if forward_all {
-                l_subscriptions.iter().collect::<Vec<(
-                    &Pubkey,
-                    &TokioSender<Result<SubscribePacketsResponse, Status>>,
-                )>>()
+            for (pubkey, sender) in if forward_all {
+                l_subscriptions.iter()
             } else {
                 slot_leaders
                     .iter()
                     .filter_map(|pubkey| l_subscriptions.get(pubkey).map(|sender| (pubkey, sender)))
-                    .collect()
-            };
-
-            for (pubkey, sender) in senders {
+            } {
                 // try send because it's a bounded channel and we don't want to block if the channel is full
                 match sender.try_send(Ok(SubscribePacketsResponse {
                     header: Some(Header {

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -223,7 +223,8 @@ struct Args {
     disable_mempool: bool,
 
     /// Forward all received packets to all connected validators,
-    /// regardless of leader schedule
+    /// regardless of leader schedule.  
+    /// Note: This is required to be true for Stake Weighted Quality of Service (SWQOS)!
     #[arg(long, env, default_value_t = false)]
     forward_all: bool,
 

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -222,6 +222,10 @@ struct Args {
     #[arg(long, env, default_value_t = false)]
     disable_mempool: bool,
 
+    /// Forward all received packets, regardless of leader schedule
+    #[arg(long, env, default_value_t = false)]
+    forward_all: bool,
+
     /// Staked Nodes Overrides Path
     /// "Provide path to a yaml file with custom overrides for stakes of specific
     ///  identities. Overriding the amount of stake this validator considers as valid
@@ -513,6 +517,7 @@ fn main() {
         ofac_addresses,
         address_lookup_table_cache,
         args.validator_packet_batch_size,
+        args.forward_all,
     );
 
     let priv_key = fs::read(&args.signing_key_pem_path).unwrap_or_else(|_| {

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -229,11 +229,11 @@ struct Args {
     forward_all: bool,
 
     /// Staked Nodes Overrides Path
-    /// "Provide path to a yaml file with custom overrides for stakes of specific
+    /// `Provide path to a yaml file with custom overrides for stakes of specific
     ///  identities. Overriding the amount of stake this validator considers as valid
     ///  for other peers in network. The stake amount is used for calculating the
     ///  number of QUIC streams permitted from the peer and vote packet sender stage.
-    ///  Format of the file: `staked_map_id: {<pubkey>: <SOL stake amount>}"
+    ///  Format of the file: `staked_map_id: {<pubkey>: <SOL stake amount>}`
     #[arg(long, env)]
     staked_nodes_overrides: Option<PathBuf>,
 }

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -229,11 +229,11 @@ struct Args {
     forward_all: bool,
 
     /// Staked Nodes Overrides Path
-    /// `Provide path to a yaml file with custom overrides for stakes of specific
+    /// Provide path to a yaml file with custom overrides for stakes of specific
     ///  identities. Overriding the amount of stake this validator considers as valid
     ///  for other peers in network. The stake amount is used for calculating the
     ///  number of QUIC streams permitted from the peer and vote packet sender stage.
-    ///  Format of the file: `staked_map_id: {<pubkey>: <SOL stake amount>}`
+    ///  Format of the file: `staked_map_id: {<pubkey>: <SOL stake amount>}
     #[arg(long, env)]
     staked_nodes_overrides: Option<PathBuf>,
 }

--- a/transaction-relayer/src/main.rs
+++ b/transaction-relayer/src/main.rs
@@ -222,7 +222,8 @@ struct Args {
     #[arg(long, env, default_value_t = false)]
     disable_mempool: bool,
 
-    /// Forward all received packets, regardless of leader schedule
+    /// Forward all received packets to all connected validators,
+    /// regardless of leader schedule
     #[arg(long, env, default_value_t = false)]
     forward_all: bool,
 


### PR DESCRIPTION
The  original design of the relayer was to serve as a proxy for many validators.  While this is still one use, it is also being used by validators to serve a single identity.

This PR adds the ability to bypass the leader schedule check and forwards all valid (post-sigverify/dedup) packets to any connected leader.  This should make the relayer more resilient to network forking.

If testing of this PR is successful, a future PR will remove the dependency on the websocket connection to the validator when this flag is enabled, which will remove the need for `--full-rpc-api` in the validator for co-hosted setups.

Note: This also updates several dependencies to address security reports from dependabot.